### PR TITLE
chore(websocket-server): update version to 1.0.7 and enhance logging in ws_service

### DIFF
--- a/engine/shared/astronverse-websocket-server/pyproject.toml
+++ b/engine/shared/astronverse-websocket-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "astronverse-websocket-server"
-version = "1.0.1"
+version = "1.0.7"
 description = "astronverse-websocket-server."
 requires-python = ">=3.13"
 

--- a/engine/uv.lock
+++ b/engine/uv.lock
@@ -797,7 +797,7 @@ requires-dist = [{ name = "websocket-client" }]
 
 [[package]]
 name = "astronverse-websocket-server"
-version = "1.0.1"
+version = "1.0.7"
 source = { editable = "shared/astronverse-websocket-server" }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [x] ✨ 新功能 | New Feature
- [ ] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

---

## 🔗 相关 Issue | Related Issues

<!-- 关联相关的 Issue，使用 "Closes #123" 或 "Fixes #123" 可以在合并时自动关闭 Issue -->
<!-- Link related issues using "Closes #123" or "Fixes #123" to auto-close them on merge -->

- Closes #
- Related to #

---

## 📋 变更内容 | Changes Made

<!-- 详细描述你做了哪些变更，为什么要做这些变更 -->
<!-- Describe in detail what changes you made and why -->

### 主要变更 | Main Changes

- Bump version of astronverse-websocket-server from 1.0.1 to 1.0.7 in both uv.lock and pyproject.toml.
- Improve logging in ws_service.py to avoid excessive logs for ping/pong messages while still capturing illegal messages for debugging purposes.
- Refactor _send_exit method to ensure proper error handling and cleanup during connection termination.

### 技术细节 | Technical Details

<!-- 如有必要，说明技术实现细节 -->
<!-- If necessary, explain technical implementation details -->

---

## 🧪 测试 | Testing

<!-- 描述你如何测试这些变更 -->
<!-- Describe how you tested these changes -->

### 测试环境 | Test Environment

- [ ] Windows 10/11
- [ ] Linux
- [ ] macOS
- [ ] Docker

### 测试步骤 | Test Steps

1. 
2. 
3. 

### 测试结果 | Test Results

<!-- 简要说明测试结果 -->
<!-- Briefly describe test results -->

---

## 📸 截图/录屏 | Screenshots/Recordings

<!-- 如果是 UI 变更，请提供截图或录屏 -->
<!-- If UI changes, please provide screenshots or recordings -->

### 变更前 | Before

<!-- 放置截图 -->

### 变更后 | After

<!-- 放置截图 -->

---

## ⚠️ 破坏性变更 | Breaking Changes

<!-- 如果有破坏性变更，请详细说明并提供迁移指南 -->
<!-- If there are breaking changes, please explain in detail and provide migration guide -->

- [ ] 此 PR 包含破坏性变更 | This PR contains breaking changes

<details>
<summary>破坏性变更详情 | Breaking Changes Details</summary>

<!-- 详细描述破坏性变更 -->
<!-- Describe breaking changes in detail -->

</details>

---

## ✅ 检查清单 | Checklist

### 代码质量 | Code Quality

- [ ] 代码遵循项目的编码规范 | Code follows project coding standards
- [ ] 已进行自我代码审查 | Self-reviewed the code
- [ ] 代码有适当的注释（特别是复杂逻辑）| Code has appropriate comments (especially for complex logic)
- [ ] 更新了相关文档 | Updated relevant documentation
- [ ] 没有产生新的警告 | No new warnings generated

### 测试 | Testing

- [ ] 添加了相应的测试用例 | Added corresponding test cases
- [ ] 所有测试通过 | All tests pass
- [ ] 手动测试验证通过 | Manual testing verification passed

### 文档 | Documentation

- [ ] 更新了 README（如需要）| Updated README (if needed)
- [ ] 更新了 API 文档（如需要）| Updated API documentation (if needed)
- [ ] 更新了用户指南（如需要）| Updated user guide (if needed)
- [ ] 更新了 CHANGELOG（如需要）| Updated CHANGELOG (if needed)

### 其他 | Others

- [ ] 已与相关利益方沟通 | Communicated with relevant stakeholders
- [ ] 不影响现有功能 | Does not affect existing functionality
- [ ] 考虑了向后兼容性 | Considered backward compatibility
- [ ] 考虑了性能影响 | Considered performance impact
- [ ] 考虑了安全性 | Considered security

---

## 📌 额外说明 | Additional Notes

<!-- 其他需要评审者注意的信息 -->
<!-- Other information that reviewers should be aware of -->

---

## 🙏 致谢 | Acknowledgements

<!-- 如果有协作者或参考资料，请在此列出 -->
<!-- If there are collaborators or references, please list them here -->

---

**📖 提示 | Tips:**
- 确保 PR 标题简洁明了，使用动词开头（例如：Add, Fix, Update, Remove）
- Ensure PR title is concise and clear, starting with a verb (e.g., Add, Fix, Update, Remove)
- 尽量保持 PR 的改动范围小而集中，便于审查
- Try to keep PR changes small and focused for easier review
- 遵循项目的分支管理策略
- Follow the project's branch management strategy

---

/cc @maintainers <!-- 根据需要 @ 相关维护者 | Mention relevant maintainers as needed -->

