### PR TITLE
fix(params): handle empty Python type values by setting them to None

### DIFF
--- a/engine/servers/astronverse-executor/src/astronverse/executor/flow/params.py
+++ b/engine/servers/astronverse-executor/src/astronverse/executor/flow/params.py
@@ -58,6 +58,7 @@ class Param(IParam):
         预处理参数
         1. 预处理data优先
         2. 过筛前端无效数据
+        3. 如果数组只有一个且type是python且value为""的时候，把value设置为None
         """
 
         ls = []
@@ -70,6 +71,7 @@ class Param(IParam):
         ):
             # 预处理1: 处理data优先
             # 预处理2: 过略前端无效数据
+            # 预处理3: 如果数组只有一个且type是python且value为""的时候，把value设置为None
             for v in param_value:
                 if "data" not in v:
                     v["data"] = v.get("value", "")
@@ -78,6 +80,8 @@ class Param(IParam):
                     ls.append(v)
             if len(ls) == 0:
                 ls.append(param_value[0])
+            if len(ls) == 1 and ls[0].get("type") == ParamType.PYTHON.value and ls[0].get("data") == "":
+                ls[0]["data"] = None
         else:
             ls = [{"type": ParamType.OTHER.value, "data": param_value}]
         return ls

--- a/engine/servers/astronverse-picker/src/astronverse/picker/utils/params.py
+++ b/engine/servers/astronverse-picker/src/astronverse/picker/utils/params.py
@@ -96,6 +96,7 @@ class ComplexParamParser:
         ):
             # 预处理1: 处理data优先
             # 预处理2: 过略前端无效数据
+            # 预处理3: 如果数组只有一个且type是python且value为""的时候，把value设置为None
             for v in param_value:
                 if "data" not in v:
                     v["data"] = v.get("value", "")
@@ -104,6 +105,8 @@ class ComplexParamParser:
                     ls.append(v)
             if len(ls) == 0:
                 ls.append(param_value[0])
+            if len(ls) == 1 and ls[0].get("type") == ParamType.PYTHON.value and ls[0].get("data") == "":
+                ls[0]["data"] = None
         else:
             ls = [{"type": ParamType.OTHER.value, "data": param_value}]
         return ls


### PR DESCRIPTION
- Added logic to set the value to None if the parameter array contains a single item of Python type with an empty string value, improving data handling consistency in both executor and picker modules.

## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [ ] ✨ 新功能 | New Feature
- [X] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

/cc @horizon220222 

