### PR TITLE
fix(params): update need_parse type from boolean to string in agent a…

### DIFF
--- a/engine/components/astronverse-ai/src/astronverse/ai/agent.py
+++ b/engine/components/astronverse-ai/src/astronverse/ai/agent.py
@@ -229,7 +229,7 @@ class Agent:
             atomicMg.param(
                 "astron_workflow",
                 formType=AtomicFormTypeMeta(type=AtomicFormType.AIWORKFLOW.value),
-                need_parse="json_str",
+                need_parse="str",
             )
         ],
         outputList=[atomicMg.param("astron_agent_result", types="Str")],

--- a/engine/components/astronverse-script/src/astronverse/script/script.py
+++ b/engine/components/astronverse-script/src/astronverse/script/script.py
@@ -135,7 +135,7 @@ class Script:
             atomicMg.param(
                 "process_param",
                 types="List",
-                need_parse=True,
+                need_parse="str",
                 formType=AtomicFormTypeMeta(type=AtomicFormType.PROCESSPARAM.value, params={"linkage": "process"}),
                 required=False,
             ),
@@ -169,7 +169,7 @@ class Script:
             atomicMg.param(
                 "module_param",
                 types="List",
-                need_parse=True,
+                need_parse="str",
                 formType=AtomicFormTypeMeta(type=AtomicFormType.PROCESSPARAM.value, params={"linkage": "content"}),
                 required=False,
             ),


### PR DESCRIPTION
…nd script components

- Changed the `need_parse` parameter from `True` to `"str"` in both the `Agent` and `Script` classes to ensure consistent data handling for parameter parsing.

## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [ ] ✨ 新功能 | New Feature
- [X] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

/cc @horizon220222 