### PR TITLE
fix: remove unnecessary flags from atomic_run in AST processing

### DIFF
--- a/engine/servers/astronverse-executor/src/astronverse/executor/flow/flow.py
+++ b/engine/servers/astronverse-executor/src/astronverse/executor/flow/flow.py
@@ -19,10 +19,11 @@ class Flow:
 
     def gen_component(self, path: str, project_id: str, mode: str, version: str):
         """遍历组件列表，为每个组件生成独立目录、main 入口并注册组件信息。"""
-        os.makedirs(path, exist_ok=True)
         component_list = self.svc.storage.component_list(project_id=project_id, mode=mode, version=version)
         if not component_list:
             return
+
+        os.makedirs(path, exist_ok=True)
 
         # 并发生成所有组件
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:

--- a/engine/servers/astronverse-executor/src/astronverse/executor/flow/syntax/ast.py
+++ b/engine/servers/astronverse-executor/src/astronverse/executor/flow/syntax/ast.py
@@ -203,8 +203,6 @@ class Atomic(Node):
                 continue  # 这些由外层处理，不传给 atomic_run
             else:
                 modified_arguments.append(param.show())
-        # 添加标记，告诉 atomic_run 跳过 START 上报
-        modified_arguments.append("__in_external_retry__=True")
 
         # 生成函数调用代码
         src = self.token.value.get("src")
@@ -274,7 +272,6 @@ class Atomic(Node):
                 continue
             else:
                 modified_arguments.append(param.show())
-        modified_arguments.append("__in_external_retry__=True")
 
         # 生成函数调用代码
         src = self.token.value.get("src")


### PR DESCRIPTION
- Eliminated the "__in_external_retry__=True" flag from the modified arguments in the Atomic class to streamline the function call process.
- Ensured that the directory creation for components is consistently handled in the gen_component method.

## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [ ] ✨ 新功能 | New Feature
- [ ] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [X] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update



/cc @horizon220222 

