### PR TITLE
fix(path): use native open command for macOS file/folder opening

### DIFF
--- a/frontend/packages/electron-app/src/main/path.ts
+++ b/frontend/packages/electron-app/src/main/path.ts
@@ -40,7 +40,7 @@ export function openPath(targetPath: string): Promise<void> {
     targetPath = path.resolve(targetPath)
 
     // 根据操作系统选择命令
-    const openCommand = process.platform === 'win32' ? `start "" "${targetPath}"` : `xdg-open "${targetPath}"`
+    const openCommand = process.platform === 'win32' ? `start "" "${targetPath}"` : process.platform === 'darwin' ? `open "${targetPath}"` : `xdg-open "${targetPath}"`
 
     exec(openCommand, (error) => {
       error ? reject(error) : resolve()


### PR DESCRIPTION
Replace xdg-open with platform-native open command on macOS, ensuring correct behavior across win32, darwin, and linux.

## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [ ] ✨ 新功能 | New Feature
- [X] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

