### PR TITLE
fix(build): delete existing python_core archive before compression

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -284,6 +284,7 @@ REM 4.4. Package and Release
 REM ============================================
 
 echo Compressing python_core directory...
+if exist "%SCRIPT_DIR%\%ARCHIVE_DIST_DIR%\python_core.7z" del /f /q "%SCRIPT_DIR%\%ARCHIVE_DIST_DIR%\python_core.7z"
 cd /d "%PYTHON_CORE_DIR%"
 "%SEVENZ_EXE%" a -t7z "%SCRIPT_DIR%\%ARCHIVE_DIST_DIR%\python_core.7z" "*" >nul
 cd /d "%SCRIPT_DIR%"


### PR DESCRIPTION
Ensure that any existing python_core.7z archive is deleted prior to creating a new compressed version. This prevents potential conflicts and ensures the latest version is always packaged.

## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [X] ✨ 新功能 | New Feature
- [ ] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

