### PR TITLE
Refactor: rename macOS build commands to use 'darwin' terminology

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -328,7 +328,7 @@ else
 
     echo "Building desktop application..."
     if [[ "$(uname)" == "Darwin" ]]; then
-        BUILD_CMD="build:mac"
+        BUILD_CMD="build:darwin"
     else
         BUILD_CMD="build:linux"
     fi

--- a/frontend/packages/electron-app/README.md
+++ b/frontend/packages/electron-app/README.md
@@ -27,7 +27,7 @@ $ pnpm dev
 $ pnpm build:win
 
 # For macOS
-$ pnpm build:mac
+$ pnpm build:darwin
 
 # For Linux
 $ pnpm build:linux

--- a/frontend/packages/electron-app/package.json
+++ b/frontend/packages/electron-app/package.json
@@ -21,7 +21,7 @@
     "build:unpack": "npm run build && electron-builder --config electron-builder-config.js --dir",
     "build:win": "npm run build && electron-builder --config electron-builder-config.js --win",
     "build:win32": "npm run build && electron-builder --config electron-builder-config.js --win --ia32",
-    "build:mac": "npm run build && electron-builder --config electron-builder-config.js --mac",
+    "build:darwin": "npm run build && electron-builder --config electron-builder-config.js --darwin",
     "build:linux": "npm run build && electron-builder --config electron-builder-config.js --linux",
     "build:sdk": "tsdown --config tsdown.config.mts",
     "build:web": "pnpm --filter @rpa/web-app run build && npm run copy:renderer",

--- a/frontend/packages/shared/src/platform/utils.ts
+++ b/frontend/packages/shared/src/platform/utils.ts
@@ -34,7 +34,7 @@ function hasFlag(flag: string) {
 
 function parsePlatformFromArgv() {
   if (hasFlag('--win')) return 'win32'
-  if (hasFlag('--mac')) return 'darwin'
+  if (hasFlag('--darwin')) return 'darwin'
   if (hasFlag('--linux')) return 'linux'
   return process.platform
 }


### PR DESCRIPTION
- Updated build commands in package.json and README.md to replace 'build:mac' with 'build:darwin'.
- Adjusted platform detection in utils.ts to recognize '--darwin' flag instead of '--mac'.

## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [X] ✨ 新功能 | New Feature
- [ ] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

