### PR TITLE
fix(atomic): adjust result handling in AtomicManager for specific key

### DIFF
--- a/engine/shared/astronverse-actionlib/src/astronverse/actionlib/atomic.py
+++ b/engine/shared/astronverse-actionlib/src/astronverse/actionlib/atomic.py
@@ -153,7 +153,10 @@ class AtomicManager:
         # 2. 高级参数处理
         has_result = True
         if self.atomic_dict[key].outputList is None or len(self.atomic_dict[key].outputList) == 0:
-            has_result = False
+            if key in ["Script.component"]:
+                has_result = True
+            else:
+                has_result = False
 
         if delay_before > 0:
             time.sleep(delay_before)


### PR DESCRIPTION
- Modified the condition for determining the presence of results in AtomicManager. Now, if the key is "Script.component", it will always return true for has_result, ensuring that this specific case is handled correctly.

## 📝 Pull Request 描述 | Description

<!-- 请简要描述此 PR 的目的和内容 -->
<!-- Please provide a brief description of this PR -->

### 🎯 变更类型 | Change Type

<!-- 请勾选适用的类型 -->
<!-- Please check the applicable type -->

- [ ] ✨ 新功能 | New Feature
- [X] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [ ] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

