### PR TITLE
fix: harden resource file validation

### DIFF
--- a/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/controller/FileController.java
+++ b/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/controller/FileController.java
@@ -7,6 +7,7 @@ import com.iflytek.rpa.resource.file.entity.enums.FileType;
 import com.iflytek.rpa.resource.file.entity.vo.ShareFileUploadVo;
 import com.iflytek.rpa.resource.file.service.FileService;
 import java.io.IOException;
+import java.util.Locale;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -99,9 +100,8 @@ public class FileController {
     private void checkVideo(MultipartFile file) {
         // 校验视频文件格式
         String originalFilename = file.getOriginalFilename();
-        String fileExtension = originalFilename
-                .substring(originalFilename.lastIndexOf(".") + 1)
-                .toLowerCase();
+        String fileExtension =
+                StringUtils.substringAfterLast(originalFilename, ".").toLowerCase(Locale.ROOT);
         String[] allowedVideoFormats = {"mp4", "webm", "ogg", "avi", "mov", "mpeg"};
 
         boolean isValidFormat = false;
@@ -121,9 +121,22 @@ public class FileController {
     private void checkParam(MultipartFile file, long maxSize) {
         if (file == null || file.isEmpty()) throw new ServiceException(ErrorCodeEnum.E_PARAM_LOSE.getCode(), "文件不能为空");
 
-        if (file.getSize() > maxSize) throw new ServiceException(ErrorCodeEnum.E_PARAM_CHECK.getCode(), "文件大小不能超过50MB");
+        if (file.getSize() > maxSize)
+            throw new ServiceException(ErrorCodeEnum.E_PARAM_CHECK.getCode(), "文件大小不能超过" + formatFileSize(maxSize));
 
         if (StringUtils.isBlank(file.getOriginalFilename()))
             throw new ServiceException(ErrorCodeEnum.E_PARAM_LOSE.getCode(), "文件名不能为空");
+    }
+
+    private String formatFileSize(long size) {
+        long mb = 1024L * 1024L;
+        long kb = 1024L;
+        if (size > 0 && size % mb == 0) {
+            return size / mb + "MB";
+        }
+        if (size > 0 && size % kb == 0) {
+            return size / kb + "KB";
+        }
+        return size + "B";
     }
 }

--- a/backend/resource-service/src/test/java/com/iflytek/rpa/resource/file/controller/FileControllerTest.java
+++ b/backend/resource-service/src/test/java/com/iflytek/rpa/resource/file/controller/FileControllerTest.java
@@ -1,0 +1,61 @@
+package com.iflytek.rpa.resource.file.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.iflytek.rpa.resource.common.exp.ServiceException;
+import com.iflytek.rpa.resource.common.response.AppResponse;
+import com.iflytek.rpa.resource.file.service.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class FileControllerTest {
+
+    private FileController fileController;
+    private FileService fileService;
+
+    @BeforeEach
+    void setUp() {
+        fileController = new FileController();
+        fileService = Mockito.mock(FileService.class);
+        ReflectionTestUtils.setField(fileController, "fileService", fileService);
+        ReflectionTestUtils.setField(fileController, "maxFileSize", 1024L);
+        ReflectionTestUtils.setField(fileController, "maxShareSize", 2048L);
+    }
+
+    @Test
+    void uploadFileUsesConfiguredMaxSizeInErrorMessage() {
+        MockMultipartFile file = new MockMultipartFile("file", "large.txt", "text/plain", new byte[1025]);
+
+        assertThatThrownBy(() -> fileController.uploadFile(file))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("文件大小不能超过1KB");
+    }
+
+    @Test
+    void uploadVideoRejectsFilenameWithoutExtension() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "video", "video/mp4", new byte[] {1});
+
+        assertThatThrownBy(() -> fileController.uploadVideoFile(file))
+                .isInstanceOf(ServiceException.class)
+                .hasMessage("视频文件格式不支持，仅支持：mp4, webm, ogg, avi, mov, mpeg");
+        verify(fileService, never()).uploadFile(file);
+    }
+
+    @Test
+    void uploadVideoAcceptsCaseInsensitiveVideoExtension() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "video.MP4", "video/mp4", new byte[] {1});
+        when(fileService.uploadFile(file)).thenReturn(AppResponse.success("file-id"));
+
+        AppResponse<String> response = fileController.uploadVideoFile(file);
+
+        assertThat(response.getData()).isEqualTo("file-id");
+        verify(fileService).uploadFile(file);
+    }
+}


### PR DESCRIPTION
## 📝 Pull Request 描述 | Description

修复 `resource-service` 文件上传校验中的两个健壮性问题：

1. 上传视频文件时，如果文件名没有扩展名，原逻辑会直接截取后缀，可能导致异常或错误判断。
2. 文件大小超限提示固定写死为 `50MB`，但实际限制来自配置项 `file.maxFileSize` / `file.maxShareSize`，提示可能与配置不一致。

### 🎯 变更类型 | Change Type

- [ ] ✨ 新功能 | New Feature
- [x] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [x] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

---

## 🔗 相关 Issue | Related Issues

- Closes #792

---

## 📋 变更内容 | Changes Made

### 主要变更 | Main Changes

- 使用 `StringUtils.substringAfterLast` 安全提取视频文件扩展名，避免无扩展名文件触发不必要异常。
- 使用 `Locale.ROOT` 处理扩展名大小写转换，保持格式判断稳定。
- 文件大小超限提示改为根据实际配置值动态生成，例如 `50MB`、`100MB`、`1KB`。
- 新增 `FileControllerTest`，覆盖视频格式校验和文件大小提示逻辑。

### 技术细节 | Technical Details

- 未新增外部依赖，复用项目已有的 `commons-lang3`。
- 无扩展名视频文件会被正常识别为不支持格式，并返回业务异常。
- `formatFileSize` 会按 `MB`、`KB`、`B` 输出配置限制，避免提示与配置不一致。

---

## 🧪 测试 | Testing

### 测试环境 | Test Environment

- [x] Windows 10/11
- [ ] Linux
- [ ] macOS
- [ ] Docker

### 测试步骤 | Test Steps

1. 使用 JDK 21 运行 resource-service 目标单测：
   `mvn -q -Dtest=FileControllerTest test`
2. 编译 resource-service：
   `mvn -q -DskipTests compile`
3. 运行代码格式检查：
   `mvn -q spotless:check`

### 测试结果 | Test Results

以上命令均通过。

---

## 📸 截图/录屏 | Screenshots/Recordings

### 变更前 | Before

N/A

### 变更后 | After

N/A

---

## ⚠️ 破坏性变更 | Breaking Changes

- [ ] 此 PR 包含破坏性变更 | This PR contains breaking changes

<details>
<summary>破坏性变更详情 | Breaking Changes Details</summary>

N/A

</details>

---

## ✅ 检查清单 | Checklist

### 代码质量 | Code Quality

- [x] 代码遵循项目的编码规范 | Code follows project coding standards
- [x] 已进行自我代码审查 | Self-reviewed the code
- [x] 代码有适当的注释（特别是复杂逻辑）| Code has appropriate comments (especially for complex logic)
- [ ] 更新了相关文档 | Updated relevant documentation
- [x] 没有产生新的警告 | No new warnings generated

### 测试 | Testing

- [x] 添加了相应的测试用例 | Added corresponding test cases
- [x] 所有测试通过 | All tests pass
- [ ] 手动测试验证通过 | Manual testing verification passed

### 文档 | Documentation

- [ ] 更新了 README（如需要）| Updated README (if needed)
- [ ] 更新了 API 文档（如需要）| Updated API documentation (if needed)
- [ ] 更新了用户指南（如需要）| Updated user guide (if needed)
- [ ] 更新了 CHANGELOG（如需要）| Updated CHANGELOG (if needed)

### 其他 | Others

- [ ] 已与相关利益方沟通 | Communicated with relevant stakeholders
- [x] 不影响现有功能 | Does not affect existing functionality
- [x] 考虑了向后兼容性 | Considered backward compatibility
- [x] 考虑了性能影响 | Considered performance impact
- [x] 考虑了安全性 | Considered security

---

## 📌 额外说明 | Additional Notes

本 PR 仅调整 `resource-service` 的文件参数校验逻辑，改动范围较小，不涉及接口协议变更。

---

## 🙏 致谢 | Acknowledgements

感谢 Issue #792 的反馈。

---

/cc @maintainers