### PR TITLE
docs: add star support call-to-action

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -23,3 +23,6 @@ contact_links:
   - name: 🐛 已知问题
     url: https://github.com/iflytek/astron-rpa/labels/bug
     about: 查看已知问题和正在处理的 Bug 列表
+  - name: ⭐ 支持我们
+    url: https://github.com/iflytek/astron-rpa/stargazers
+    about: 如果 AstronRPA 对你有帮助，点个 Star 支持项目发展，让更多人发现它

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ We welcome any form of contribution! Please check [Contributing Guide](CONTRIBUT
 
 ## 🌟 Star History
 
+If AstronRPA saves you time, consider giving it a ⭐ — it is the simplest way to support the project and helps other automation builders discover it.
+
 <div align="center">
   <img src="https://api.star-history.com/svg?repos=iflytek/astron-rpa&type=Date" alt="Star History Chart" width="600">
 </div>

--- a/README.zh.md
+++ b/README.zh.md
@@ -194,6 +194,8 @@ docker compose ps
 
 ## 🌟 Star 历史
 
+如果 AstronRPA 帮你省下了时间，欢迎点一个 ⭐——这是支持项目最简单的方式，也能让更多自动化开发者发现它。
+
 <div align="center">
   <img src="https://api.star-history.com/svg?repos=iflytek/astron-rpa&type=Date" alt="Star 历史图表" width="600">
 </div>


### PR DESCRIPTION
## What

Adds a lightweight "star support" call-to-action at two places where visitors already are:

1. **`README.md` / `README.zh.md`** - one sentence above the existing Star History chart. The chart was there with no ask; now it explains why a star matters (discoverability), in both languages.
2. **`.github/ISSUE_TEMPLATE/config.yml`** - a `⭐ 支持我们` contact link on the new-issue chooser, pointing at the stargazers page.

## Why

GitHub Traffic "popular content" for this repo shows the issues pages among the highest-traffic landing surfaces, and views convert poorly to stars today. The issue chooser is seen by every visitor who clicks "New issue", so a low-key support link there reaches peak-traffic pages without adding noise to any individual template.

## Notes

- `config.yml` stays valid YAML (checked with a YAML parser) and existing contact links are untouched
- No layout changes; three small insertions total