### PR TITLE
fix(ai-service): preserve versioned API base paths

### DIFF
--- a/backend/ai-service/app/routers/v1/chat.py
+++ b/backend/ai-service/app/routers/v1/chat.py
@@ -1,5 +1,4 @@
 import json
-from urllib.parse import urljoin
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -11,9 +10,10 @@ from app.schemas.chat import ChatCompletionParam, ChatPromptParam
 from app.services.chat import chat_completions
 from app.services.point import PointTransactionType
 from app.utils.prompt import format_prompt, get_available_prompts, prompt_dict
+from app.utils.url import join_api_url
 
 API_KEY = get_settings().AICHAT_API_KEY
-API_ENDPOINT = urljoin(get_settings().AICHAT_BASE_URL, "chat/completions")
+API_ENDPOINT = join_api_url(get_settings().AICHAT_BASE_URL, "chat/completions")
 
 logger = get_logger(__name__)
 
@@ -27,7 +27,9 @@ router = APIRouter(
 async def chat(
     params: ChatCompletionParam,
     points_context: PointsContext = Depends(
-        PointChecker(get_settings().AICHAT_POINTS_COST, PointTransactionType.AICHAT_COST),
+        PointChecker(
+            get_settings().AICHAT_POINTS_COST, PointTransactionType.AICHAT_COST
+        ),
     ),
 ):
     response = await chat_completions(params, API_KEY, API_ENDPOINT)
@@ -41,7 +43,9 @@ async def chat(
 async def chat_prompt(
     params: ChatPromptParam,
     points_context: PointsContext = Depends(
-        PointChecker(get_settings().AICHAT_POINTS_COST, PointTransactionType.AICHAT_COST),
+        PointChecker(
+            get_settings().AICHAT_POINTS_COST, PointTransactionType.AICHAT_COST
+        ),
     ),
 ):
     """

--- a/backend/ai-service/app/routers/v1/models.py
+++ b/backend/ai-service/app/routers/v1/models.py
@@ -1,14 +1,13 @@
-from urllib.parse import urljoin
-
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.config import get_settings
 from app.dependencies import get_user_id_from_header
 from app.logger import get_logger
+from app.utils.url import join_api_url
 
 API_KEY = get_settings().AICHAT_API_KEY
-API_ENDPOINT = urljoin(get_settings().AICHAT_BASE_URL, "models")
+API_ENDPOINT = join_api_url(get_settings().AICHAT_BASE_URL, "models")
 
 logger = get_logger(__name__)
 
@@ -42,7 +41,9 @@ async def list_models(current_user_id: str = Depends(get_user_id_from_header)):
 
 
 @router.get("/{model_id}")
-async def get_model(model_id: str, current_user_id: str = Depends(get_user_id_from_header)):
+async def get_model(
+    model_id: str, current_user_id: str = Depends(get_user_id_from_header)
+):
     """
     Get details of a specific model.
     """

--- a/backend/ai-service/app/services/chat.py
+++ b/backend/ai-service/app/services/chat.py
@@ -1,5 +1,3 @@
-from urllib.parse import urljoin
-
 import httpx
 from fastapi import HTTPException
 from fastapi.responses import Response, StreamingResponse
@@ -7,9 +5,10 @@ from fastapi.responses import Response, StreamingResponse
 from app.config import get_settings
 from app.logger import get_logger
 from app.schemas.chat import ChatCompletionParam
+from app.utils.url import join_api_url
 
 API_KEY = get_settings().AICHAT_API_KEY
-API_ENDPOINT = urljoin(get_settings().AICHAT_BASE_URL, "chat/completions")
+API_ENDPOINT = join_api_url(get_settings().AICHAT_BASE_URL, "chat/completions")
 
 logger = get_logger(__name__)
 
@@ -21,7 +20,9 @@ long_timeout = httpx.Timeout(
 )
 
 
-async def chat_completions(params: ChatCompletionParam, key: str = API_KEY, endpoint: str = API_ENDPOINT):
+async def chat_completions(
+    params: ChatCompletionParam, key: str = API_KEY, endpoint: str = API_ENDPOINT
+):
     logger.info("Processing chat completion request...")
     logger.info(f"Request params: {params}")
     # 构造请求参数
@@ -72,7 +73,9 @@ async def handle_stream_request(headers, data, endpoint):
                     json=data,
                 ) as upstream_response:
                     upstream_response.raise_for_status()
-                    response_meta["media_type"] = upstream_response.headers.get("content-type", "text/event-stream")
+                    response_meta["media_type"] = upstream_response.headers.get(
+                        "content-type", "text/event-stream"
+                    )
                     async for chunk in upstream_response.aiter_raw():
                         yield chunk
             except httpx.HTTPStatusError as e:

--- a/backend/ai-service/app/utils/url.py
+++ b/backend/ai-service/app/utils/url.py
@@ -1,0 +1,7 @@
+from urllib.parse import urljoin
+
+
+def join_api_url(base_url: str, path: str) -> str:
+    """Join an API path without dropping a version prefix from the base URL."""
+    normalized_base = f"{base_url.rstrip('/')}/"
+    return urljoin(normalized_base, path.lstrip("/"))

--- a/backend/ai-service/tests/utils/test_url.py
+++ b/backend/ai-service/tests/utils/test_url.py
@@ -1,0 +1,31 @@
+import pytest
+
+from app.utils.url import join_api_url
+
+
+@pytest.mark.parametrize(
+    ("base_url", "path", "expected"),
+    [
+        (
+            "https://api.atlascloud.ai/v1",
+            "models",
+            "https://api.atlascloud.ai/v1/models",
+        ),
+        (
+            "https://api.atlascloud.ai/v1/",
+            "/chat/completions",
+            "https://api.atlascloud.ai/v1/chat/completions",
+        ),
+        (
+            "http://localhost:11434/v1",
+            "chat/completions",
+            "http://localhost:11434/v1/chat/completions",
+        ),
+    ],
+)
+def test_join_api_url_preserves_base_path(
+    base_url: str,
+    path: str,
+    expected: str,
+) -> None:
+    assert join_api_url(base_url, path) == expected


### PR DESCRIPTION
## Summary

- add a small API URL join helper that preserves a path prefix such as `/v1`
- use it for model discovery and both chat-completions call sites
- add regression coverage for versioned base URLs with and without a trailing slash

## Problem

`urllib.parse.urljoin(base_url, "models")` treats the final segment of a base URL without a trailing slash as a file. For example, `https://api.atlascloud.ai/v1` was resolved to `https://api.atlascloud.ai/models`, dropping the required `/v1` prefix. The same issue affected `chat/completions`.

## Validation

- `uv run --frozen pytest tests/utils/test_url.py -q` (`3 passed`)
- `uv run --frozen ruff check` on all changed Python files
- `uv run --frozen ruff format --check` on all changed Python files
- Python 3.13 `compileall` on all changed Python files
- imported all three call sites with `AICHAT_BASE_URL=https://api.atlascloud.ai/v1` and verified `/v1/models` plus `/v1/chat/completions`

The project lock currently omits the already-declared `pytz` dependency, so it was installed only in the local test environment; this PR does not change dependency metadata or the lock file.

## Scope

No README, documentation, environment example, UI, logo, sponsor, credits, or partner changes.
