### PR TITLE
docs(readme): fix the broken star-history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We welcome any form of contribution! Please check [Contributing Guide](CONTRIBUT
 If AstronRPA saves you time, consider giving it a ⭐ — it is the simplest way to support the project and helps other automation builders discover it.
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-rpa&type=Date" alt="Star History Chart" width="600">
+  <img src="https://afterglow.watch/svg?repos=iflytek/astron-rpa&type=Date" alt="Star History Chart" width="600">
 </div>
 
 ## 💖 Sponsorship


### PR DESCRIPTION
The star-history chart near the bottom of the README has been a broken image since GitHub removed the stargazer endpoints at the end of June; api.star-history.com no longer renders the /svg URLs.

There are two real fixes, and this PR is only one of them. You can keep star-history: they now revive the old chart if you fetch a sealed_token URL from their site, which keeps the full pre-June history. Or take this PR, which points the chart at afterglow.watch, same URL shape, daily snapshots, free, no token, but the measured line starts July 31, when tracking began. There's also a badge in the social style if you want it to match your others:

    https://afterglow.watch/badge/iflytek/astron-rpa?style=social

I run afterglow.watch, so I'm not neutral here. Deleting the dead embed is also a fine fix. Happy to close this whichever way you go.
