### PR TITLE
fix(script): return Python module result

### DIFF
--- a/engine/components/astronverse-script/src/astronverse/script/script.py
+++ b/engine/components/astronverse-script/src/astronverse/script/script.py
@@ -68,7 +68,7 @@ class Script:
                 )
 
             res = main_func(out_kwargs)
-            return out_kwargs
+            return res
         else:
             report.warning(ReportTip(msg_str=MSG_MODULE_VERSION_WARRING))
 

--- a/engine/components/astronverse-script/tests/test_script.py
+++ b/engine/components/astronverse-script/tests/test_script.py
@@ -1,4 +1,6 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from astronverse.script.script import Script
 
@@ -33,6 +35,21 @@ def main(param1, param2):
         # 验证结果
         expected = {"result": "value1_value2", "status": "success"}
         self.assertEqual(result, expected)
+
+    def test_module_call_v2_returns_main_result(self):
+        """V2 modules should return main(args), not the input argument mapping."""
+        process_module = SimpleNamespace(main=lambda args: {"result": args["value"].upper()})
+
+        with patch("astronverse.script.script.importlib.import_module", return_value=process_module):
+            result = Script._module_call(
+                ".example",
+                package="test_package",
+                out_kwargs={"value": "input"},
+                out_param_meta=[],
+                inn_kwargs={},
+            )
+
+        assert result == {"result": "INPUT"}
 
     def test_module_without_main_function(self):
         """测试不包含main函数的脚本执行"""


### PR DESCRIPTION
## What changed

- return the actual result of `main(args)` from the v2 Python module execution path
- add a focused regression test that distinguishes the function result from the input argument mapping

## Why

The v2 path invoked `main(out_kwargs)` but discarded its return value and returned `out_kwargs` instead. As a result, the Python module component exposed its input parameters rather than the value produced by user code.

Fixes #803.

## Impact

Only the v2 `main(args)` module path changes. The legacy `main(**kwargs)` path is unchanged. Callers now receive the documented user-code result.

## Validation

- Python 3.13 focused regression test: 1 passed
- Ruff format check on both changed files: passed
- Ruff check on both changed files passed after excluding their pre-existing baseline rules: F401, F403, F405, S307, RUF013, PT009, and PT027
- `git diff --check`: passed

## Existing test baseline

Running the complete `test_script.py` currently yields 1 pass and 5 pre-existing failures: those older tests pass `__env__` to `Script.module`, but the current decorated method rejects that keyword before reaching the code changed here. The new regression test passes, and this PR does not modify that unrelated test/API drift.