### PR TITLE
fix(web): wire global request loading

### DIFF
--- a/frontend/packages/web-app/src/api/http/index.ts
+++ b/frontend/packages/web-app/src/api/http/index.ts
@@ -14,6 +14,7 @@ import { promiseWithResolvers } from '@/utils/common'
 import { ERROR_CODES, SUCCESS_CODES, UN_AUTHORIZED_CODES } from '@/constants'
 
 import { getBaseURL, unauthorize } from './env'
+import { globalLoadingTracker, shouldTrackGlobalLoading } from './loading'
 
 export type { AxiosProgressEvent } from 'axios'
 
@@ -94,8 +95,8 @@ class HttpClient {
       }
 
       // 在这里可以添加请求拦截器的逻辑，例如添加请求头、处理请求参数等
-      if (config.loading) {
-        // TODO: 添加全局 loading
+      if (shouldTrackGlobalLoading(config.loading)) {
+        globalLoadingTracker.start()
       }
 
       config.headers['Accept-Language'] = i18next.language
@@ -106,8 +107,8 @@ class HttpClient {
     this.instance.interceptors.response.use(
       (response: Response) => {
         // 在这里可以添加响应拦截器的逻辑，例如处理响应数据、处理错误等
-        if (response.config.loading) {
-          // 关闭loading
+        if (shouldTrackGlobalLoading(response.config.loading)) {
+          globalLoadingTracker.finish()
         }
 
         if (response.config.responseType === 'blob') {
@@ -145,7 +146,11 @@ class HttpClient {
       },
       (error) => {
         // 在这里可以处理请求错误，例如显示错误提示、跳转到错误页面等
-        if (error.config.toast !== false) {
+        if (error.config && shouldTrackGlobalLoading(error.config.loading)) {
+          globalLoadingTracker.finish()
+        }
+
+        if (error.config?.toast !== false) {
           if (error.response) {
             const msg = error.response?.status === 403 ? i18next.t('noPermission') : `${error.response.status} ${error.response.statusText}`
             message.error(msg)

--- a/frontend/packages/web-app/src/api/http/loading.test.ts
+++ b/frontend/packages/web-app/src/api/http/loading.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  GlobalLoadingTracker,
+  shouldTrackGlobalLoading,
+} from './loadingTracker'
+
+describe('GlobalLoadingTracker', () => {
+  it('keeps loading open until every concurrent request finishes', () => {
+    const open = vi.fn()
+    const close = vi.fn()
+    const tracker = new GlobalLoadingTracker(open, close)
+
+    tracker.start()
+    tracker.start()
+    expect(open).toHaveBeenCalledTimes(1)
+
+    tracker.finish()
+    expect(close).not.toHaveBeenCalled()
+
+    tracker.finish()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores unmatched finishes', () => {
+    const open = vi.fn()
+    const close = vi.fn()
+    const tracker = new GlobalLoadingTracker(open, close)
+
+    tracker.finish()
+    tracker.finish()
+
+    expect(open).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+  })
+})
+
+describe('shouldTrackGlobalLoading', () => {
+  it('tracks loading unless it is explicitly disabled', () => {
+    expect(shouldTrackGlobalLoading()).toBe(true)
+    expect(shouldTrackGlobalLoading(false)).toBe(false)
+  })
+})

--- a/frontend/packages/web-app/src/api/http/loading.ts
+++ b/frontend/packages/web-app/src/api/http/loading.ts
@@ -1,0 +1,10 @@
+import globalLoading from '@/utils/globalLoading'
+
+import { GlobalLoadingTracker } from './loadingTracker'
+
+export { shouldTrackGlobalLoading } from './loadingTracker'
+
+export const globalLoadingTracker = new GlobalLoadingTracker(
+  () => globalLoading.open({}),
+  () => globalLoading.close(),
+)

--- a/frontend/packages/web-app/src/api/http/loadingTracker.ts
+++ b/frontend/packages/web-app/src/api/http/loadingTracker.ts
@@ -1,0 +1,31 @@
+export function shouldTrackGlobalLoading(loading?: boolean) {
+  return loading !== false
+}
+
+export class GlobalLoadingTracker {
+  private activeRequests = 0
+
+  constructor(
+    private readonly open: () => void,
+    private readonly close: () => void,
+  ) {}
+
+  start() {
+    if (this.activeRequests === 0) {
+      this.open()
+    }
+
+    this.activeRequests += 1
+  }
+
+  finish() {
+    if (this.activeRequests === 0) {
+      return
+    }
+
+    this.activeRequests -= 1
+    if (this.activeRequests === 0) {
+      this.close()
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- wire the existing global Loading component into HttpClient request and response interceptors
- enable global loading by default while preserving explicit loading: false opt-outs
- keep a concurrency-safe request counter so overlapping requests do not close the indicator early
- close loading on successful and failed requests, including requests without toast handling
- add focused tests for concurrent requests, unmatched completions, and default/opt-out behavior

## Validation
- local Node assertions for concurrent and opt-out behavior
- TypeScript 5.9.3 isolated type check
- git diff --check

The full frontend workspace install could not complete locally because the package mirror repeatedly timed out; repository CI should run the complete suite.

Closes #794