### PR TITLE
fix(browser): 下载另存为改用 WM_SETTEXT 直写，消除剪贴板污染与焦点竞争

### DIFF
--- a/engine/components/astronverse-browser/src/astronverse/browser/core/core_win.py
+++ b/engine/components/astronverse-browser/src/astronverse/browser/core/core_win.py
@@ -107,10 +107,22 @@ class BrowserCore:
             return text
 
         # 判断是否弹出下载窗口
-        dialog = win32gui.FindWindow("#32770", "另存为")  # 一级窗口
+        # 「另存为」对话框标题随系统语言变化（issue #791）：
+        # 中文为「另存为」，英文为「Save As」，日文为「名前を付けて保存」等，
+        # 依次尝试各语言标题，避免在非中文 Windows 上找不到窗口。
+        save_as_titles = ["另存为", "另存新檔", "Save As", "名前を付けて保存", "다른 이름으로 저장"]
+
+        def find_dialog():
+            for title in save_as_titles:
+                hwnd = win32gui.FindWindow("#32770", title)  # 一级窗口
+                if hwnd:
+                    return hwnd
+            return 0
+
+        dialog = find_dialog()
         start_time = time.time()
         while time.time() - start_time < 10:
-            dialog = win32gui.FindWindow("#32770", "另存为")  # 一级窗口
+            dialog = find_dialog()
             if dialog == 0:
                 time.sleep(0.1)
             else:
@@ -120,7 +132,15 @@ class BrowserCore:
             raise BaseException(DOWNLOAD_WINDOW_NO_FIND, "未弹出下载窗口")
 
         # 查找到edit， button
-        button = win32gui.FindWindowEx(dialog, 0, "Button", "保存(S)")
+        # 「保存(S)」按钮文案随语言变化，改用标准文件对话框默认按钮的控件 ID
+        # （IDOK=1，与下方 WM_COMMAND 的 wParam 一致），不依赖按钮文案；
+        # 取不到再回退到按标题查找，兼容非标准对话框。
+        button = win32gui.GetDlgItem(dialog, win32con.IDOK)
+        if not button:
+            for _caption in ("保存(S)", "保存", "Save", "저장(S)"):
+                button = win32gui.FindWindowEx(dialog, 0, "Button", _caption)
+                if button:
+                    break
 
         a1 = win32gui.FindWindowEx(dialog, None, "DUIViewWndClassName", None)
         a2 = win32gui.FindWindowEx(a1, None, "DirectUIHWND", None)
@@ -181,10 +201,20 @@ class BrowserCore:
         browser_type = kwargs.get("browser_type")
 
         # 判断是否弹出上传窗口
-        dialog = win32gui.FindWindow("#32770", "打开")
+        # 「打开」对话框标题随系统语言变化（issue #791），依次尝试各语言标题。
+        open_titles = ["打开", "開啟", "Open", "開く", "열기"]
+
+        def find_dialog():
+            for title in open_titles:
+                hwnd = win32gui.FindWindow("#32770", title)  # 一级窗口
+                if hwnd:
+                    return hwnd
+            return 0
+
+        dialog = find_dialog()
         start_time = time.time()
         while time.time() - start_time < 10:
-            dialog = win32gui.FindWindow("#32770", "打开")  # 一级窗口
+            dialog = find_dialog()
             if dialog == 0:
                 time.sleep(0.1)
             else:
@@ -193,7 +223,14 @@ class BrowserCore:
         if dialog == 0:
             raise BaseException(UPLOAD_WINDOW_NO_FIND, "未弹出上传窗口")
 
-        button = win32gui.FindWindowEx(dialog, 0, "Button", "打开(O)")  # 四级
+        # 「打开(O)」按钮文案随语言变化，改用默认按钮控件 ID（IDOK=1），
+        # 回退到按标题查找。
+        button = win32gui.GetDlgItem(dialog, win32con.IDOK)  # 四级
+        if not button:
+            for _caption in ("打开(O)", "打开", "Open", "열기(O)"):
+                button = win32gui.FindWindowEx(dialog, 0, "Button", _caption)
+                if button:
+                    break
 
         a1 = win32gui.FindWindowEx(dialog, 0, "ComboBoxEx32", None)  # 二级
         a2 = win32gui.FindWindowEx(a1, 0, "ComboBox", None)  # 三级

--- a/engine/components/astronverse-browser/src/astronverse/browser/core/core_win.py
+++ b/engine/components/astronverse-browser/src/astronverse/browser/core/core_win.py
@@ -88,9 +88,7 @@ class BrowserCore:
     def download_window_operate(**kwargs) -> Any:
         """获取浏览器下载文件另存为窗口"""
 
-        import pyperclip
         import win32con
-        import pyautogui
         import win32gui
 
         file_name = kwargs.get("file_name")
@@ -148,15 +146,14 @@ class BrowserCore:
             dest_path = os.path.join(kwargs.get("save_path"), name + "." + suffix)
         else:
             dest_path = os.path.join(kwargs.get("save_path"), name)
-        pyperclip.copy(dest_path)
 
-        # 等待一段时间，以确保字符串已复制到剪贴板
+        # 直接向 Edit 控件句柄写入路径，避免经由系统剪贴板 + Ctrl+V：
+        # 剪贴板是全局共享资源，粘贴依赖窗口焦点，二者在人工辅助、
+        # 多机器人并发或前台窗口切换时会互相污染 / 抢焦点（见 issue #795）。
+        # upload_window_operate 已采用同样的 WM_SETTEXT 直写方式。
+        win32gui.SendMessage(edit, win32con.WM_SETTEXT, None, dest_path)  # 写入文件路径
         time.sleep(0.5)
-
-        # 模拟 Ctrl+V 粘贴操作
-        pyautogui.hotkey("ctrl", "v")
-        time.sleep(0.5)
-        win32gui.SendMessage(dialog, win32con.WM_COMMAND, 1, button)  # 点击打开按钮
+        win32gui.SendMessage(dialog, win32con.WM_COMMAND, 1, button)  # 点击保存按钮
 
         if is_wait:
             if not (time_out == 0 or time_out == ""):


### PR DESCRIPTION
Closes #795

## 问题

`download_window_operate`（`engine/components/astronverse-browser/.../core/core_win.py`）在填写"另存为"对话框路径时，走的是**剪贴板 + 模拟 Ctrl+V**：

```python
pyperclip.copy(dest_path)
time.sleep(0.5)
pyautogui.hotkey("ctrl", "v")
```

正如 #795 指出的，剪贴板是全局共享资源、粘贴又依赖窗口焦点，这两点恰好在 RPA 的典型运行场景下不成立：

1. **人工辅助场景**：机器人运行时用户也在操作电脑，会互相覆盖剪贴板——机器人冲掉用户刚复制的内容，或用户的复制让机器人粘错路径。
2. **前台窗口竞争**：`pyautogui` 的按键是全局的，`time.sleep(0.5)` 期间若有弹窗（系统更新、IM 消息）抢走焦点，`Ctrl+V` 会发到错误的窗口。
3. **多实例并发**：单机跑多个机器人时共享同一个系统剪贴板，彼此干扰。

## 改动

改为把路径**直接 `WM_SETTEXT` 写入 Edit 控件句柄**——不经过剪贴板、也不要求窗口在前台：

```python
win32gui.SendMessage(edit, win32con.WM_SETTEXT, None, dest_path)
```

复用的正是方法里**已经找到的 `edit` 句柄**（原代码取它只为读默认文件名，现在顺带用于写入）。顺手移除本方法内不再需要的 `pyperclip`、`pyautogui` 两个 import。

**这不是新方案**：同文件的 `upload_window_operate`（上传"打开"对话框）本来就是用 `WM_SETTEXT` 直写的（第 215 行）。本 PR 只是让下载侧和上传侧一致，采用同一套更稳健的做法——这也是 #795 明确建议的参考实现。

## 验证

- `py_compile` 通过；确认 `pyperclip`/`pyautogui` 在该方法内无残留引用（二者原本就只在此方法用到）。
- 这段是 Win32 GUI 交互代码，和 `upload_window_operate` 一样无法脱离真实 Windows 桌面做单元测试。改动是**用同文件已在生产使用的写入方式替换脆弱的剪贴板路径**，行为等价（把 `dest_path` 送进同一个 Edit 控件），风险面小。
- 保留了原有 `time.sleep(0.5)` 与点击保存按钮的时序，只替换"如何把文本送进输入框"这一步。

diff 仅 6 行增、9 行删。


---

## 追加：修复对话框标题/按钮硬编码中文（Closes #791）

`core_win.py` 定位 Windows 文件对话框及其默认按钮时，用的是硬编码简体中文文案
（`另存为`/`保存(S)` 与 `打开`/`打开(O)`）。在非中文 Windows（英文、日文…）上
`FindWindow`/`FindWindowEx` 返回 0，整个下载/上传流程失败。

- 对话框标题改为**按语言候选列表**依次匹配（zh-CN / zh-TW / en / ja / ko），
  不再只认单一中文标题；
- 保存/打开按钮改用**控件 ID**（`IDOK == 1`，本就是下方 `WM_COMMAND` 的 wParam）
  定位，取不到再回退到按标题查找 —— 不再依赖按钮文案。

中文系统行为完全不变（中文标题/文案排在候选首位先命中），其他语言环境也能正常工作。
