### PR TITLE
fix(browser): preserve multi-dot download filenames

### DIFF
--- a/engine/components/astronverse-browser/src/astronverse/browser/core/core_win.py
+++ b/engine/components/astronverse-browser/src/astronverse/browser/core/core_win.py
@@ -131,7 +131,7 @@ class BrowserCore:
         edit = win32gui.FindWindowEx(a4, None, "Edit", None)
         origin_name = get_text_from_edit(edit)
         if origin_name.find(".") != -1:
-            name = origin_name.split(".")[0]
+            name = origin_name.rsplit(".", 1)[0]
             suffix = origin_name.rsplit(".", 1)[-1]
             if not suffix.isalpha():
                 name = origin_name

--- a/engine/components/astronverse-browser/tests/test_download_window.py
+++ b/engine/components/astronverse-browser/tests/test_download_window.py
@@ -1,0 +1,51 @@
+import sys
+from types import ModuleType
+
+from astronverse.browser.core import core_win
+
+
+def test_download_window_waits_for_filename_with_multiple_dots(monkeypatch):
+    origin_name = "report.v1.pdf"
+    expected_path = "/downloads/report.v1.pdf"
+
+    win32con = ModuleType("win32con")
+    win32con.WM_GETTEXTLENGTH = 1
+    win32con.WM_GETTEXT = 2
+    win32con.WM_COMMAND = 3
+
+    win32gui = ModuleType("win32gui")
+    win32gui.FindWindow = lambda *_args: 1
+    win32gui.FindWindowEx = lambda *_args: 2
+    win32gui.PyMakeBuffer = bytearray
+    win32gui.PyGetBufferAddressAndLen = lambda buffer: (buffer, len(buffer))
+    win32gui.PyGetString = lambda _buffer, _length: origin_name
+
+    def send_message(_hwnd, message, *_args):
+        if message == win32con.WM_GETTEXTLENGTH:
+            return len(origin_name)
+        return 0
+
+    win32gui.SendMessage = send_message
+
+    pyperclip = ModuleType("pyperclip")
+    pyperclip.copy = lambda _value: None
+    pyautogui = ModuleType("pyautogui")
+    pyautogui.hotkey = lambda *_args: None
+
+    monkeypatch.setitem(sys.modules, "win32con", win32con)
+    monkeypatch.setitem(sys.modules, "win32gui", win32gui)
+    monkeypatch.setitem(sys.modules, "pyperclip", pyperclip)
+    monkeypatch.setitem(sys.modules, "pyautogui", pyautogui)
+    monkeypatch.setattr(core_win.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(core_win.os.path, "exists", lambda path: path == expected_path)
+
+    result = core_win.BrowserCore.download_window_operate(
+        browser_type="chrome",
+        is_wait=True,
+        time_out=3,
+        file_name="",
+        custom_flag=False,
+        save_path="/downloads",
+    )
+
+    assert result == expected_path


### PR DESCRIPTION
## 📝 Pull Request 描述 | Description

Preserve the complete filename stem when the Windows Save As dialog reports a
name containing multiple periods.

### 🎯 变更类型 | Change Type

- [ ] ✨ 新功能 | New Feature
- [x] 🐛 Bug 修复 | Bug Fix
- [ ] 📚 文档更新 | Documentation
- [ ] 🎨 代码格式/样式 | Code Style
- [ ] ♻️ 重构 | Refactoring
- [ ] ⚡ 性能优化 | Performance
- [x] ✅ 测试相关 | Tests
- [ ] 🔧 配置变更 | Configuration
- [ ] 🔨 构建/CI | Build/CI
- [ ] 🌐 国际化 | Internationalization
- [ ] ⬆️ 依赖升级 | Dependencies Update

---

## 🔗 相关 Issue | Related Issues

- Related to #610

---

## 📋 变更内容 | Changes Made

### 主要变更 | Main Changes

- Split the detected download filename at its final period, preserving stems
  such as `report.v1`.
- Add a platform-independent regression that simulates the Win32 Save As APIs
  and a completed `report.v1.pdf` download.

### 技术细节 | Technical Details

`download_window_operate` previously combined the text before the first
period with the suffix after the final period. For `report.v1.pdf`, it saved
and polled `report.pdf`, so the actual completed file was never observed and
the workflow waited until timeout.

---

## 🧪 测试 | Testing

### 测试环境 | Test Environment

- [ ] Windows 10/11
- [ ] Linux
- [x] macOS
- [ ] Docker

### 测试步骤 | Test Steps

1. Run the regression on the unchanged base: it fails with
   `等待下载完成超时`.
2. Apply the one-line filename parsing fix and rerun: 1/1 passes.
3. Run the executable browser component suite, Ruff, format, Python 3.13
   compilation, and diff validation.

### 测试结果 | Test Results

- Failing before:
  `PYTHONPATH=engine/components/astronverse-browser/src:engine/shared/astronverse-baseline/src uv run --python 3.13 --with pytest --no-project pytest -q engine/components/astronverse-browser/tests/test_download_window.py`
  exited 1.
- Passing after: the same command passed 1/1.
- Browser component suite passed 1/1 after excluding the pre-existing
  `test_browser_open_demo.py`, which cannot collect on Darwin because the
  repository's clipboard implementation explicitly rejects that platform.
- Ruff check (with only the file's pre-existing `I001` and `PLR1714`
  findings excluded), Ruff format, Python 3.13 compilation, and
  `git diff --check` passed.

---

## 📸 截图/录屏 | Screenshots/Recordings

Not applicable; this is a filename parsing and completion-polling fix covered
by a simulated Win32 regression.

---

## ⚠️ 破坏性变更 | Breaking Changes

- [ ] 此 PR 包含破坏性变更 | This PR contains breaking changes

No breaking changes.

---

## ✅ 检查清单 | Checklist

### 代码质量 | Code Quality

- [x] 代码遵循项目的编码规范 | Code follows project coding standards
- [x] 已进行自我代码审查 | Self-reviewed the code
- [x] 代码有适当的注释（特别是复杂逻辑）| Code has appropriate comments (especially for complex logic)
- [x] 更新了相关文档 | Updated relevant documentation (not needed)
- [x] 没有产生新的警告 | No new warnings generated

### 测试 | Testing

- [x] 添加了相应的测试用例 | Added corresponding test cases
- [x] 所有可执行的相关测试通过 | All executable relevant tests pass
- [ ] 手动测试验证通过 | Manual testing verification passed

### 文档 | Documentation

- [x] 更新了 README（如需要）| Updated README (not needed)
- [x] 更新了 API 文档（如需要）| Updated API documentation (not needed)
- [x] 更新了用户指南（如需要）| Updated user guide (not needed)
- [x] 更新了 CHANGELOG（如需要）| Updated CHANGELOG (not needed)

### 其他 | Others

- [ ] 已与相关利益方沟通 | Communicated with relevant stakeholders
- [x] 不影响现有功能 | Does not affect existing functionality
- [x] 考虑了向后兼容性 | Considered backward compatibility
- [x] 考虑了性能影响 | Considered performance impact
- [x] 考虑了安全性 | Considered security

---

## 📌 额外说明 | Additional Notes

Open PR #839 changes how the same dialog receives the destination path
(clipboard to `WM_SETTEXT`) but retains the filename parsing shown here; the
two fixes address independent behavior.

---

## 🙏 致谢 | Acknowledgements

Thanks to the reporter of #610 for documenting the completed-download workflow
stall.
