### PR TITLE
fix(ai-service): reject naive expiration dates

### DIFF
--- a/backend/ai-service/app/models/point.py
+++ b/backend/ai-service/app/models/point.py
@@ -104,10 +104,9 @@ def calculate_expiration_date(allocation_type, policy=None, reference_date=None,
     if reference_date is None:
         reference_date = datetime.now(target_timezone)
     else:
-        # 确保reference_date有时区信息
-        if reference_date.tzinfo is None:
-            # 假设naive datetime是业务时区的时间
-            reference_date = reference_date.replace(tzinfo=BUSINESS_TIMEZONE)
+        # 拒绝含义不明确的时间，而不是静默假设其所在时区
+        if reference_date.tzinfo is None or reference_date.utcoffset() is None:
+            raise ValueError("reference_date must be timezone-aware")
         # 转换到目标时区
         reference_date = reference_date.astimezone(target_timezone)
 

--- a/backend/ai-service/tests/models/test_point.py
+++ b/backend/ai-service/tests/models/test_point.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.point import PointExpirationPolicy, calculate_expiration_date
+
+
+def test_calculate_expiration_date_rejects_naive_reference_date():
+    reference_date = datetime(2026, 8, 14, 12)
+
+    with pytest.raises(ValueError, match="reference_date must be timezone-aware"):
+        calculate_expiration_date(
+            "manual_add",
+            policy=PointExpirationPolicy.THIRTY_DAYS,
+            reference_date=reference_date,
+        )
+
+
+def test_calculate_expiration_date_accepts_timezone_aware_reference_date():
+    reference_date = datetime(2026, 8, 14, 12, tzinfo=timezone(timedelta(hours=8)))
+
+    result = calculate_expiration_date(
+        "manual_add",
+        policy=PointExpirationPolicy.THIRTY_DAYS,
+        reference_date=reference_date,
+        target_timezone=timezone.utc,
+    )
+
+    assert result == datetime(2026, 9, 13, 4, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

- reject timezone-naive `reference_date` values instead of silently treating them as Asia/Shanghai time
- preserve timezone conversion and expiration calculation for aware datetimes
- add regression coverage for both naive and aware inputs

## Root cause

`calculate_expiration_date()` accepted a naive datetime and attached `BUSINESS_TIMEZONE` with `replace(tzinfo=...)`. That made the result depend on an undocumented caller convention and could introduce an unintended offset.

## Validation

- `uv run --no-sync --project backend/ai-service pytest backend/ai-service/tests/models/test_point.py -q` (`2 passed`)
- `uv run --no-sync --project backend/ai-service ruff check backend/ai-service/app/models/point.py backend/ai-service/tests/models/test_point.py`
- `uv run --no-sync --project backend/ai-service ruff format --check backend/ai-service/tests/models/test_point.py`

Closes #841