### PR TITLE
feat: add initial RISC-V backend support

### DIFF
--- a/.github/workflows/build-push-backend.yml
+++ b/.github/workflows/build-push-backend.yml
@@ -224,7 +224,7 @@ jobs:
         with:
           context: .
           file: ./backend/resource-service/Dockerfile
-          platforms: ${{ needs.detect-and-prepare.outputs.platforms }}
+          platforms: linux/amd64,linux/arm64,linux/riscv64
           push: ${{ needs.detect-and-prepare.outputs.should-push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -355,7 +355,8 @@ jobs:
           echo "🔍 Project Detection: ${{ needs.detect-and-prepare.result }}"
           echo "📊 Version: ${{ needs.detect-and-prepare.outputs.version }}"
           echo "📤 Push to Registry: ${{ needs.detect-and-prepare.outputs.should-push }}"
-          echo "🏗️ Target Platforms: ${{ needs.detect-and-prepare.outputs.platforms }}"
+          echo "🏗️ Default Target Platforms: ${{ needs.detect-and-prepare.outputs.platforms }}"
+          echo "📦 Resource Service Platforms: linux/amd64,linux/arm64,linux/riscv64"
           echo "🔧 Services: ${{ needs.detect-and-prepare.outputs.services }}"
           echo ""
 

--- a/.github/workflows/riscv64-resource-service.yml
+++ b/.github/workflows/riscv64-resource-service.yml
@@ -1,0 +1,46 @@
+name: RISC-V Resource Service
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/riscv64-resource-service.yml'
+      - 'backend/resource-service/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build resource-service (linux/riscv64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build RISC-V image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./backend/resource-service/Dockerfile
+          platforms: linux/riscv64
+          load: true
+          tags: astron-rpa/resource-service:riscv64-ci
+          cache-from: type=gha,scope=riscv64-resource-service
+          cache-to: type=gha,mode=max,scope=riscv64-resource-service
+
+      - name: Verify image architecture and Java runtime
+        shell: bash
+        run: |
+          image=astron-rpa/resource-service:riscv64-ci
+          test "$(docker image inspect "$image" --format '{{.Architecture}}')" = riscv64
+          docker run --rm --platform linux/riscv64 --entrypoint java "$image" -version

--- a/backend/resource-service/Dockerfile
+++ b/backend/resource-service/Dockerfile
@@ -1,7 +1,9 @@
+# syntax=docker/dockerfile:1
+
 # 多阶段构建 Dockerfile for Java 21 Spring Boot Application
 
 # 第一阶段：构建JAR包
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-21 AS build
 
 # 设置工作目录
 WORKDIR /app
@@ -19,7 +21,7 @@ COPY backend/resource-service/src ./src
 RUN mvn clean package -DskipTests
 
 # 第二阶段：构建可执行镜像
-FROM eclipse-temurin:21-jre AS runtime
+FROM eclipse-temurin:21-jre-noble AS runtime
 
 # 设置工作目录
 WORKDIR /app

--- a/docs/RISCV64.md
+++ b/docs/RISCV64.md
@@ -1,0 +1,55 @@
+# RISC-V (`linux/riscv64`) support
+
+## Current scope
+
+RISC-V support is incremental and currently applies only to the server-side
+`resource-service` image. It does not add RISC-V support for the Astron RPA
+Windows desktop client or automation engine, and it does not make the complete
+Docker Compose stack supported on RISC-V.
+
+| Component | `linux/riscv64` status | Notes |
+| --- | --- | --- |
+| `resource-service` | Supported image path | The architecture-neutral Java 21 JAR is built on the Buildx host and copied into a target-architecture Eclipse Temurin runtime. |
+| `ai-service` and `openapi-service` | Not yet verified | Python 3.13 native dependencies and the bundled wheel require an architecture audit. |
+| `robot-service` and `rpa-auth` | Not yet verified | Their Java 8 build/runtime images require a separate RISC-V compatibility path. |
+| MySQL, Redis, MinIO, Casdoor, Atlas, and OpenResty | Not yet verified as a stack | Each external image and its runtime behavior must be checked on the target system. |
+| Windows desktop client and automation engine | Unsupported | These components depend on Windows desktop and UI automation capabilities and are outside this server-image adaptation. |
+| Complete Compose deployment | Unsupported | Do not deploy `docker/docker-compose.yml` unchanged as a supported RISC-V stack. |
+
+## Build the supported image
+
+Run the build from the repository root. Register a RISC-V QEMU handler first
+when the Buildx host is not RISC-V:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install riscv64
+docker buildx create --use --name astron-rpa-riscv64
+
+docker buildx build \
+  --platform linux/riscv64 \
+  --file backend/resource-service/Dockerfile \
+  --tag astron-rpa/resource-service:riscv64 \
+  --load \
+  .
+```
+
+The backend publishing workflow produces `resource-service` for
+`linux/amd64`, `linux/arm64`, and `linux/riscv64`. The other backend service
+jobs retain the existing AMD64/ARM64 platform list.
+
+## Build design
+
+The Maven stage runs on `$BUILDPLATFORM` because the Spring Boot JAR is
+architecture-neutral. Only the Eclipse Temurin Java 21 runtime stage targets
+`linux/riscv64`. This avoids emulating dependency resolution and compilation
+while preserving the existing application entry point and JVM options.
+
+## Verification boundary
+
+The pull-request workflow builds and loads the target image, checks its OCI
+architecture metadata, and executes the Java runtime under RISC-V emulation.
+This is a component-image guardrail, not a full application integration test.
+
+A native RISC-V smoke test with the database, cache, object storage,
+authentication service, reverse proxy, and an RPA client remains required
+before claiming end-to-end or production support.


### PR DESCRIPTION
## Description

This PR adds an initial, explicitly scoped `linux/riscv64` backend image path for Astron RPA. The supported unit is the Java 21 `resource-service`; this PR does **not** claim RISC-V support for the Windows desktop client, automation engine, the other backend services, or the complete Docker Compose stack.

### Change type

- [x] New Feature
- [x] Documentation
- [x] Build/CI
- [x] Configuration

## Motivation

This change is part of the iFLYTEK community adaptation work for the [Open Source Promotion Plan 2026](https://docs2026.summer.ospp.ac.cn/help/CommunityGuide).

Astron RPA contains services with materially different portability constraints: Java 21, Java 8, Python 3.13 with native dependencies, Windows desktop automation, and multiple third-party runtime images. Adding RISC-V to the shared platform variable would imply support for all five backend images without evidence. This PR therefore expands one service with a maintainable build path and documents the remaining boundary.

## Main changes

- Build the architecture-neutral `resource-service` JAR on `$BUILDPLATFORM`.
- Use the Eclipse Temurin 21 Noble runtime, which provides a target-architecture RISC-V image.
- Publish `resource-service` for `linux/amd64,linux/arm64,linux/riscv64`.
- Keep `ai-service`, `openapi-service`, `robot-service`, and `rpa-auth` on the existing AMD64/ARM64 platform list.
- Add a pull-request workflow that builds the RISC-V image, checks OCI architecture metadata, and executes the Java runtime under QEMU.
- Add `docs/RISCV64.md` with build instructions and a component-level compatibility matrix.

## Technical design

The Spring Boot JAR does not contain an architecture-specific application binary. The Maven stage therefore runs on the Buildx host:

```dockerfile
FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-21 AS build
```

Only the runtime stage targets `linux/riscv64`:

```dockerfile
FROM eclipse-temurin:21-jre-noble AS runtime
```

This avoids emulating Maven dependency resolution and Java compilation while preserving the current entry point, port, and JVM options.

| Backend image | Published platforms after this PR |
| --- | --- |
| `resource-service` | `linux/amd64,linux/arm64,linux/riscv64` |
| `ai-service` | `linux/amd64,linux/arm64` |
| `openapi-service` | `linux/amd64,linux/arm64` |
| `robot-service` | `linux/amd64,linux/arm64` |
| `rpa-auth` | `linux/amd64,linux/arm64` |

## Testing

### Local validation

```bash
git diff --check origin/main...HEAD
```

- `git diff --check` passed.
- The workstation does not have Docker or a system Maven/JDK launcher, so a local image build and Java test suite could not run.
- The new `RISC-V Resource Service` PR workflow is the authoritative target-architecture check: it builds and loads `linux/riscv64`, verifies image metadata, and executes `java -version` under QEMU.
- Existing repository CI remains responsible for normal source-level and style validation.

## Explicit scope and limitations

- The Windows 10/11 Electron client is unchanged and remains the supported desktop client environment.
- The Windows UI automation engine is outside this server-image adaptation.
- `robot-service` and `rpa-auth` still require a verified Java 8 RISC-V path.
- `ai-service` and `openapi-service` still require a Python 3.13 native-dependency and bundled-wheel audit.
- MySQL, Redis, MinIO, Casdoor, Atlas, OpenResty, and their integration behavior are not claimed as a verified RISC-V stack.
- `docker/docker-compose.yml` must not be presented or deployed unchanged as a supported RISC-V environment.
- No API, database schema, UI, or business-logic behavior changes.

## Risk and rollback

- Existing AMD64/ARM64 publication remains enabled.
- The `resource-service` runtime base becomes the explicitly pinned Noble variant for all three architectures.
- Rollback consists of restoring the shared platform output for the resource job and reverting the two Dockerfile stage declarations.

## Follow-up work

1. Run a native-board application smoke test with the database, cache, object storage, authentication, and reverse proxy.
2. Audit Python 3.13 native dependencies and the bundled `rpawebsocket` wheel.
3. Establish a Java 8 RISC-V strategy before expanding `robot-service` or `rpa-auth`.
