### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We welcome any form of contribution! Please check [Contributing Guide](CONTRIBUT
 If AstronRPA saves you time, consider giving it a ⭐ — it is the simplest way to support the project and helps other automation builders discover it.
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-rpa&type=Date" alt="Star History Chart" width="600">
+  <img src="https://star-history.dera.page/svg?repos=iflytek/astron-rpa&type=Date" alt="Star History Chart" width="600">
 </div>
 
 ## 💖 Sponsorship

--- a/README.zh.md
+++ b/README.zh.md
@@ -200,7 +200,7 @@ docker compose ps
 如果 AstronRPA 帮你省下了时间，欢迎点一个 ⭐——这是支持项目最简单的方式，也能让更多自动化开发者发现它。
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-rpa&type=Date" alt="Star 历史图表" width="600">
+  <img src="https://star-history.dera.page/svg?repos=iflytek/astron-rpa&type=Date" alt="Star 历史图表" width="600">
 </div>
 
 ## 💖 赞助支持


### PR DESCRIPTION
The star history chart embedded in the README is currently broken because of GitHub stargazer API restrictions, which means visitors no longer see the project's growth.

This PR updates the chart URL in README.md and README.zh.md so the chart renders correctly again. It is a small, safe change limited to the README files.