### PR TITLE
fix(element): 元素重名创建失败时清理刚上传的孤儿截图

### DIFF
--- a/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/controller/FileController.java
+++ b/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/controller/FileController.java
@@ -43,6 +43,21 @@ public class FileController {
     }
 
     /**
+     * 根据文件ID删除文件
+     *
+     * @param fileId 文件ID
+     * @return 删除结果
+     */
+    @DeleteMapping("/delete")
+    public AppResponse<Boolean> deleteFile(@RequestParam("fileId") String fileId) {
+        // 参数校验
+        if (StringUtils.isEmpty(fileId)) throw new ServiceException(ErrorCodeEnum.E_PARAM_LOSE.getCode());
+
+        // 调用Service层处理业务逻辑
+        return fileService.deleteFile(fileId);
+    }
+
+    /**
      * 上传文件
      *
      * @param file 文件对象

--- a/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/service/FileService.java
+++ b/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/service/FileService.java
@@ -29,4 +29,14 @@ public interface FileService extends IService<File> {
      * @return 文件ID
      */
     AppResponse<String> uploadFile(MultipartFile file) throws IOException;
+
+    /**
+     * 根据文件ID删除文件，同时清理 S3 对象与文件记录
+     *
+     * <p>删除是幂等的：文件已被删除或从未存在时同样返回成功。</p>
+     *
+     * @param fileId 文件ID
+     * @return 删除结果
+     */
+    AppResponse<Boolean> deleteFile(String fileId);
 }

--- a/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/service/impl/FileServiceImpl.java
+++ b/backend/resource-service/src/main/java/com/iflytek/rpa/resource/file/service/impl/FileServiceImpl.java
@@ -147,6 +147,55 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         return AppResponse.success(fileId);
     }
 
+    @Override
+    public AppResponse<Boolean> deleteFile(String fileId) {
+        File file = baseMapper.getFile(fileId);
+        if (file == null) {
+            // 已删除或从未存在，删除保持幂等
+            return AppResponse.success(true);
+        }
+
+        String filePath = file.getPath();
+        if (StringUtils.isNotBlank(filePath)) {
+            deleteFileFromS3(filePath);
+        }
+
+        // file 实体带 @TableLogic，这里是逻辑删除
+        baseMapper.deleteById(file.getId());
+
+        return AppResponse.success(true);
+    }
+
+    /**
+     * 从S3删除文件
+     *
+     * @param filePath 文件路径
+     */
+    private void deleteFileFromS3(String filePath) {
+        S3Client s3Client = null;
+        try {
+            s3Client = buildS3Client();
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(s3Config.getBucket())
+                    .key(filePath)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+
+        } catch (NoSuchKeyException e) {
+            // 对象已不在S3上，视为删除成功
+        } catch (S3Exception e) {
+            throw new ServiceException(ErrorCodeEnum.E_API_EXCEPTION.getCode(), "S3删除异常: " + e.getMessage());
+        } catch (Exception e) {
+            throw new ServiceException(ErrorCodeEnum.E_EXCEPTION.getCode(), "文件删除异常: " + e.getMessage());
+        } finally {
+            if (s3Client != null) {
+                s3Client.close();
+            }
+        }
+    }
+
     /**
      * 获取文件扩展名
      *

--- a/backend/resource-service/src/test/java/com/iflytek/rpa/resource/file/controller/FileControllerTest.java
+++ b/backend/resource-service/src/test/java/com/iflytek/rpa/resource/file/controller/FileControllerTest.java
@@ -58,4 +58,20 @@ class FileControllerTest {
         assertThat(response.getData()).isEqualTo("file-id");
         verify(fileService).uploadFile(file);
     }
+
+    @Test
+    void deleteFileRejectsBlankFileId() {
+        assertThatThrownBy(() -> fileController.deleteFile("")).isInstanceOf(ServiceException.class);
+        verify(fileService, never()).deleteFile(Mockito.anyString());
+    }
+
+    @Test
+    void deleteFileDelegatesToTheService() {
+        when(fileService.deleteFile("file-id")).thenReturn(AppResponse.success(true));
+
+        AppResponse<Boolean> response = fileController.deleteFile("file-id");
+
+        assertThat(response.getData()).isTrue();
+        verify(fileService).deleteFile("file-id");
+    }
 }

--- a/backend/robot-service/src/main/java/com/iflytek/rpa/base/service/impl/CElementServiceImpl.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/base/service/impl/CElementServiceImpl.java
@@ -16,6 +16,7 @@ import com.iflytek.rpa.base.entity.vo.ElementVo;
 import com.iflytek.rpa.base.entity.vo.GroupInfoVo;
 import com.iflytek.rpa.base.service.CElementService;
 import com.iflytek.rpa.common.feign.RpaAuthFeign;
+import com.iflytek.rpa.common.feign.RpaResourceFeign;
 import com.iflytek.rpa.common.feign.entity.User;
 import com.iflytek.rpa.robot.dao.RobotDesignDao;
 import com.iflytek.rpa.utils.IdWorker;
@@ -27,6 +28,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Resource;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,6 +44,9 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service("cElementService")
 public class CElementServiceImpl extends ServiceImpl<CElementDao, CElement> implements CElementService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CElementServiceImpl.class);
+
     @Resource
     private CElementDao cElementDao;
 
@@ -58,6 +64,9 @@ public class CElementServiceImpl extends ServiceImpl<CElementDao, CElement> impl
 
     @Autowired
     private RpaAuthFeign rpaAuthFeign;
+
+    @Autowired
+    private RpaResourceFeign rpaResourceFeign;
     //    @Override
     //    @RobotVersionAnnotation
     //    public AppResponse<?> getElementNameList(BaseDto baseDto) throws NoLoginException {
@@ -257,7 +266,8 @@ public class CElementServiceImpl extends ServiceImpl<CElementDao, CElement> impl
                 element.getElementName(),
                 cGroup.getElementType());
         if (null != sameNameElement) {
-            // todo 删除oss图片
+            // 截图在本次请求中刚上传，元素记录又没有写入，这张图不会被任何元素引用，直接清理
+            deleteUnreferencedImage(element.getImageId());
             return AppResponse.error(ErrorCodeEnum.E_SERVICE, "名称重复，请重新命名");
         }
         cElementDao.insertElement(element);
@@ -265,6 +275,29 @@ public class CElementServiceImpl extends ServiceImpl<CElementDao, CElement> impl
         resultMap.put("elementId", elementId);
         resultMap.put("groupId", groupId);
         return AppResponse.success(resultMap);
+    }
+
+    /**
+     * 清理一张确定未被引用的截图。
+     *
+     * <p>只用于"图片已上传、元素记录未写入"的失败路径。删除已有元素时不能走这里：
+     * 元素带版本（robotVersion），imageId / parentImageId 常被多个版本和兄弟元素共享，
+     * 需要先做引用计数才能删，见 issue #793。</p>
+     *
+     * <p>清理失败只记日志：用户该看到的是"名称重复"，而不是一个清理错误。</p>
+     */
+    private void deleteUnreferencedImage(String imageId) {
+        if (StringUtils.isBlank(imageId)) {
+            return;
+        }
+        try {
+            AppResponse<Boolean> response = rpaResourceFeign.deleteFile(imageId);
+            if (response == null || !response.ok()) {
+                logger.warn("清理未被引用的元素截图失败, imageId: {}", imageId);
+            }
+        } catch (Exception e) {
+            logger.warn("清理未被引用的元素截图异常, imageId: {}", imageId, e);
+        }
     }
 
     @Override

--- a/backend/robot-service/src/main/java/com/iflytek/rpa/common/feign/RpaResourceFeign.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/common/feign/RpaResourceFeign.java
@@ -1,0 +1,29 @@
+package com.iflytek.rpa.common.feign;
+
+import com.iflytek.rpa.utils.response.AppResponse;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * resource-service 文件接口
+ *
+ * <p>robot-service 只保存文件ID，S3 对象的生命周期由 resource-service 管理，
+ * 因此清理孤儿文件需要经由该服务。</p>
+ */
+@FeignClient(
+        name = "rpa-resource",
+        url = "${resource.base-url:http://rpa-opensource-resource-service:8030}",
+        configuration = FeignAutoConfiguration.class)
+public interface RpaResourceFeign {
+
+    /**
+     * 根据文件ID删除文件（幂等）
+     *
+     * @param fileId 文件ID
+     * @return 删除结果
+     */
+    @DeleteMapping("/api/resource/file/delete")
+    AppResponse<Boolean> deleteFile(@RequestParam("fileId") String fileId);
+}

--- a/backend/robot-service/src/main/resources/application-local.yml
+++ b/backend/robot-service/src/main/resources/application-local.yml
@@ -70,6 +70,7 @@ mybatis-plus:
 
 
 resource:
+  base-url: http://rpa-opensource-resource-service:8030
   download:
     url: /api/resource/file/download?fileId=
 

--- a/backend/robot-service/src/test/java/com/iflytek/rpa/base/service/impl/CElementServiceImplOrphanImageTest.java
+++ b/backend/robot-service/src/test/java/com/iflytek/rpa/base/service/impl/CElementServiceImplOrphanImageTest.java
@@ -1,0 +1,124 @@
+package com.iflytek.rpa.base.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.iflytek.rpa.base.dao.CElementDao;
+import com.iflytek.rpa.base.dao.CGroupDao;
+import com.iflytek.rpa.base.entity.CElement;
+import com.iflytek.rpa.base.entity.CGroup;
+import com.iflytek.rpa.base.entity.dto.ServerBaseDto;
+import com.iflytek.rpa.common.feign.RpaAuthFeign;
+import com.iflytek.rpa.common.feign.RpaResourceFeign;
+import com.iflytek.rpa.common.feign.entity.User;
+import com.iflytek.rpa.utils.IdWorker;
+import com.iflytek.rpa.utils.response.AppResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 覆盖 issue #793 的第一处孤儿场景：图片已上传、元素因重名未入库。
+ */
+class CElementServiceImplOrphanImageTest {
+
+    private CElementServiceImpl service;
+    private CElementDao cElementDao;
+    private CGroupDao cGroupDao;
+    private RpaAuthFeign rpaAuthFeign;
+    private RpaResourceFeign rpaResourceFeign;
+
+    @BeforeEach
+    void setUp() {
+        service = new CElementServiceImpl();
+        cElementDao = mock(CElementDao.class);
+        cGroupDao = mock(CGroupDao.class);
+        rpaAuthFeign = mock(RpaAuthFeign.class);
+        rpaResourceFeign = mock(RpaResourceFeign.class);
+
+        ReflectionTestUtils.setField(service, "cElementDao", cElementDao);
+        ReflectionTestUtils.setField(service, "cGroupDao", cGroupDao);
+        ReflectionTestUtils.setField(service, "rpaAuthFeign", rpaAuthFeign);
+        ReflectionTestUtils.setField(service, "rpaResourceFeign", rpaResourceFeign);
+        ReflectionTestUtils.setField(service, "idWorker", new IdWorker());
+
+        User user = new User();
+        user.setId("user-1");
+        when(rpaAuthFeign.getLoginUser()).thenReturn(AppResponse.success(user));
+
+        CGroup existingGroup = new CGroup();
+        existingGroup.setGroupId("group-1");
+        when(cGroupDao.getGroupByGroupName(any(CGroup.class))).thenReturn(existingGroup);
+    }
+
+    @Test
+    void duplicateNameDeletesTheImageThatWasJustUploaded() throws Exception {
+        when(cElementDao.getElementSameName(anyString(), any(), anyString(), anyString(), anyString()))
+                .thenReturn(new CElement());
+        when(rpaResourceFeign.deleteFile(anyString())).thenReturn(AppResponse.success(true));
+
+        AppResponse<?> response = service.createElementByType(dto("image-1"));
+
+        assertThat(response.ok()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("名称重复，请重新命名");
+        verify(rpaResourceFeign).deleteFile(eq("image-1"));
+        verify(cElementDao, never()).insertElement(any(CElement.class));
+    }
+
+    @Test
+    void duplicateNameStillReportsTheRealErrorWhenCleanupFails() throws Exception {
+        when(cElementDao.getElementSameName(anyString(), any(), anyString(), anyString(), anyString()))
+                .thenReturn(new CElement());
+        when(rpaResourceFeign.deleteFile(anyString())).thenThrow(new RuntimeException("resource-service down"));
+
+        AppResponse<?> response = service.createElementByType(dto("image-1"));
+
+        assertThat(response.ok()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("名称重复，请重新命名");
+    }
+
+    @Test
+    void successfulCreateDeletesNothing() throws Exception {
+        when(cElementDao.getElementSameName(anyString(), any(), anyString(), anyString(), anyString()))
+                .thenReturn(null);
+
+        AppResponse<?> response = service.createElementByType(dto("image-1"));
+
+        assertThat(response.ok()).isTrue();
+        verify(rpaResourceFeign, never()).deleteFile(anyString());
+        verify(cElementDao).insertElement(any(CElement.class));
+    }
+
+    @Test
+    void duplicateNameWithoutAnImageCallsNoDelete() throws Exception {
+        when(cElementDao.getElementSameName(anyString(), any(), anyString(), anyString(), anyString()))
+                .thenReturn(new CElement());
+
+        AppResponse<?> response = service.createElementByType(dto(null));
+
+        assertThat(response.ok()).isFalse();
+        verify(rpaResourceFeign, never()).deleteFile(anyString());
+    }
+
+    private ServerBaseDto dto(String imageId) {
+        CElement element = new CElement();
+        element.setElementName("元素A");
+        element.setRobotId("robot-1");
+        element.setRobotVersion(1);
+        element.setImageId(imageId);
+
+        ServerBaseDto serverBaseDto = new ServerBaseDto();
+        serverBaseDto.setGroupName("默认分组");
+        serverBaseDto.setRobotId("robot-1");
+        serverBaseDto.setRobotVersion(1);
+        serverBaseDto.setElementType("cv");
+        serverBaseDto.setElement(element);
+        return serverBaseDto;
+    }
+}


### PR DESCRIPTION
## 📝 Pull Request 描述 | Description

修复 #793 中的第一处孤儿场景：元素创建因**重名**失败时，本次请求刚上传的拾取截图没有被清理。

`CElementServiceImpl.createElementByType` 的重名分支原本只留了一句 `// todo 删除oss图片` 就直接 `return error`，图片已经在 S3 上、元素记录又没写库，这张图当场变孤儿。用户每重试一次改名，就多漏一个对象。

### 🎯 变更类型 | Change Type

- [x] 🐛 Bug 修复 | Bug Fix
- [x] ✅ 测试相关 | Tests

---

## 🔗 相关 Issue | Related Issues

- Refs #793

按 [#793 里讨论的两步拆法](https://github.com/iflytek/astron-rpa/issues/793#issuecomment-5288597085)，这个 PR 只做**第 1 步**。

---

## 📋 变更内容 | Changes Made

### 主要变更 | Main Changes

**resource-service**（robot-service 自己没有 S3 删除入口）

- `FileService#deleteFile(fileId)` + 实现：删 S3 对象 + 逻辑删 `file` 记录
- `DELETE /api/resource/file/delete`
- 幂等：文件已删除或从未存在同样返回成功；S3 侧 `NoSuchKey` 同样视为成功

**robot-service**

- 新增 `RpaResourceFeign`，地址取 `${resource.base-url:http://rpa-opensource-resource-service:8030}`
- 重名分支改为清理 `element.getImageId()` 后再返回错误
- 清理失败只 `logger.warn`，不抛出 —— 用户该看到的是「名称重复，请重新命名」，而不是一个清理错误

### 为什么只删 `imageId`，不删 `parentImageId`

`parentImageId` 是父截图，极可能被同一元素的多个版本、以及兄弟元素共享。`imageId` 是本次请求上传、且 `insertElement` 未执行的那一张，可以确定无人引用。

### 为什么不顺手修删除元素路径

`deleteElementOrImage` 只删库记录不删 OSS，是 #793 的主场景，但元素带 `robotVersion` 版本，同一张图常被多个版本 / 兄弟元素引用。删元素时直接删 OSS 会把别人还在用的图删掉，属于不可逆的数据丢失。那条路径需要先按 `imageId` / `parentImageId` 做引用计数，并且更适合做成异步孤儿清理（GC 扫描）而不是塞进删除事务里 —— 留作第 2 步。

---

## ✅ 测试 | Testing

**本机没有 JDK / Maven，无法执行 `mvn test`，CI 是这批代码的第一次真实运行**，请以 CI 结果为准。已附带测试：

`CElementServiceImplOrphanImageTest`（新增）

- 重名时按 `imageId` 调用删除，且不写入元素
- resource-service 抛异常时，仍然返回「名称重复，请重新命名」
- 创建成功时不调用任何删除
- `imageId` 为空时不发起删除请求

`FileControllerTest`（补充）

- `fileId` 为空时拒绝，不进入 service
- 正常透传到 `fileService.deleteFile`

---

## ⚠️ 风险 | Risk

- 新增删除端点与 `/file/upload`、`/file/download` 处在同一 `/file` 前缀下，鉴权口径一致；如果希望删除接口收敛到更严格的权限，请在 review 里指出，我跟着调整。
- `resource.base-url` 有默认值，存量部署不加配置也能起；k8s 内的服务名沿用 `rpa-opensource-resource-service:8030`。
- 回滚：revert 本次提交即可，没有数据迁移。
