### PR TITLE
feat(atom): 原子能力写接口增加令牌校验与限流

### DIFF
--- a/backend/robot-service/src/main/java/com/iflytek/rpa/base/controller/CAtomController.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/base/controller/CAtomController.java
@@ -5,9 +5,11 @@ import com.iflytek.rpa.base.entity.AtomCommon;
 import com.iflytek.rpa.base.entity.dto.AtomKeyListDto;
 import com.iflytek.rpa.base.entity.dto.AtomListDto;
 import com.iflytek.rpa.base.entity.dto.SaveAtomicsDto;
+import com.iflytek.rpa.base.security.AtomAdminAccessGuard;
 import com.iflytek.rpa.base.service.CAtomMetaService;
 import com.iflytek.rpa.utils.response.AppResponse;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +23,9 @@ public class CAtomController {
 
     @Autowired
     private CAtomMetaService cAtomMetaService;
+
+    @Autowired
+    private AtomAdminAccessGuard atomAdminAccessGuard;
 
     /**
      * 获取原子能力树层级关系和公共信息
@@ -65,8 +70,9 @@ public class CAtomController {
      * 新增原子能力公共数据（types、commonAdvancedParameter、atomicTree、atomicTreeExtend）
      */
     @PostMapping("/add-common")
-    public AppResponse<?> addAtomCommonInfo(@Valid @RequestBody AtomCommon atomCommon) throws JsonProcessingException {
-        // todo 加密码，限流
+    public AppResponse<?> addAtomCommonInfo(@Valid @RequestBody AtomCommon atomCommon, HttpServletRequest request)
+            throws JsonProcessingException {
+        atomAdminAccessGuard.checkWriteAccess(request);
 
         return cAtomMetaService.addAtomCommonInfo(atomCommon);
     }
@@ -79,9 +85,10 @@ public class CAtomController {
      * @return
      */
     @PostMapping("/update-common")
-    public AppResponse<?> updateAtomCommonInfo(@Valid @RequestBody AtomCommon atomCommon)
+    public AppResponse<?> updateAtomCommonInfo(@Valid @RequestBody AtomCommon atomCommon, HttpServletRequest request)
             throws JsonProcessingException {
-        // todo 加密码，限流
+        atomAdminAccessGuard.checkWriteAccess(request);
+
         return cAtomMetaService.updateAtomCommonInfo(atomCommon);
     }
 
@@ -89,7 +96,9 @@ public class CAtomController {
      * 插入或更新原子能力定义信息（atomics），存入DB
      */
     @PostMapping("/save-atomics")
-    public AppResponse<?> saveAtomicsInfo(@RequestBody SaveAtomicsDto saveAtomicsDto) throws Exception {
+    public AppResponse<?> saveAtomicsInfo(@RequestBody SaveAtomicsDto saveAtomicsDto, HttpServletRequest request)
+            throws Exception {
+        atomAdminAccessGuard.checkWriteAccess(request);
 
         return cAtomMetaService.saveAtomicsInfo(saveAtomicsDto.getAtomMap(), saveAtomicsDto.getSaveWay());
     }

--- a/backend/robot-service/src/main/java/com/iflytek/rpa/base/security/AtomAdminAccessGuard.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/base/security/AtomAdminAccessGuard.java
@@ -1,0 +1,96 @@
+package com.iflytek.rpa.base.security;
+
+import com.iflytek.rpa.utils.IpUtil;
+import com.iflytek.rpa.utils.RedisUtils;
+import com.iflytek.rpa.utils.exception.ServiceException;
+import com.iflytek.rpa.utils.response.ErrorCodeEnum;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * 原子能力写接口的访问控制。
+ *
+ * <p>{@code /atom/add-common}、{@code /atom/update-common}、{@code /atom/save-atomics}
+ * 改写的是整个平台共用的原子能力定义，但网关对 {@code /api/robot/} 默认不做会话认证
+ * （见 {@code docker/volumes/nginx/default.conf}，为避免与认证服务循环调用），
+ * 因此这几个接口需要自己校验身份并限流，见 issue #790。</p>
+ *
+ * <p>默认拒绝：没有配置 {@code atom.admin.token} 时写接口一律拒绝，而不是放行。</p>
+ */
+@Component
+public class AtomAdminAccessGuard {
+
+    public static final String TOKEN_HEADER = "X-Atom-Admin-Token";
+
+    private static final Logger logger = LoggerFactory.getLogger(AtomAdminAccessGuard.class);
+    private static final String RATE_LIMIT_KEY_PREFIX = "rpa:atom:admin:rate:";
+
+    @Value("${atom.admin.token:}")
+    private String adminToken;
+
+    @Value("${atom.admin.rate-limit.max-requests:20}")
+    private int maxRequests;
+
+    @Value("${atom.admin.rate-limit.window-seconds:60}")
+    private long windowSeconds;
+
+    /**
+     * 校验一次原子能力写请求，不通过直接抛出 {@link ServiceException}。
+     */
+    public void checkWriteAccess(HttpServletRequest request) {
+        String clientIp = IpUtil.getIpAddr(request);
+
+        // 先限流再验令牌，令牌本身也就不会被无限次尝试
+        enforceRateLimit(clientIp);
+        verifyToken(request, clientIp);
+    }
+
+    private void verifyToken(HttpServletRequest request, String clientIp) {
+        if (StringUtils.isBlank(adminToken)) {
+            logger.warn("原子能力写接口被访问但未配置 atom.admin.token, 已拒绝, clientIp: {}", clientIp);
+            throw new ServiceException(ErrorCodeEnum.E_NO_POWER.getCode(), "原子能力写接口未启用：请先配置 atom.admin.token");
+        }
+
+        String presented = request.getHeader(TOKEN_HEADER);
+        if (StringUtils.isBlank(presented) || !constantTimeEquals(presented, adminToken)) {
+            logger.warn("原子能力写接口令牌校验失败, clientIp: {}", clientIp);
+            throw new ServiceException(ErrorCodeEnum.E_NO_POWER.getCode(), "原子能力写接口令牌校验失败");
+        }
+    }
+
+    private void enforceRateLimit(String clientIp) {
+        if (maxRequests <= 0 || windowSeconds <= 0) {
+            return;
+        }
+
+        String key = RATE_LIMIT_KEY_PREFIX + StringUtils.defaultIfBlank(clientIp, "unknown");
+        long count;
+        try {
+            count = RedisUtils.incr(key, 1);
+            if (count == 1 || RedisUtils.getExpire(key) < 0) {
+                // 计数器必须带过期时间，否则一个窗口的计数会把调用方永久挡在门外
+                RedisUtils.expire(key, windowSeconds);
+            }
+        } catch (Exception e) {
+            // Redis 不可用时不阻断：令牌校验才是这里真正的门禁，限流是纵深防御
+            logger.warn("原子能力写接口限流计数失败，本次跳过限流, clientIp: {}", clientIp, e);
+            return;
+        }
+
+        if (count > maxRequests) {
+            logger.warn("原子能力写接口触发限流, clientIp: {}, count: {}", clientIp, count);
+            throw new ServiceException(ErrorCodeEnum.E_SERVICE_POWER_LIMIT.getCode(), "请求过于频繁，请稍后再试");
+        }
+    }
+
+    private boolean constantTimeEquals(String presented, String expected) {
+        return MessageDigest.isEqual(
+                presented.getBytes(StandardCharsets.UTF_8), expected.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/backend/robot-service/src/main/resources/application-local.yml
+++ b/backend/robot-service/src/main/resources/application-local.yml
@@ -73,6 +73,15 @@ resource:
   download:
     url: /api/resource/file/download?fileId=
 
+# 原子能力写接口（/atom/add-common、/atom/update-common、/atom/save-atomics）的访问控制
+# token 为空时这些接口一律拒绝，见 issue #790
+atom:
+  admin:
+    token: ${ATOM_ADMIN_TOKEN:}
+    rate-limit:
+      max-requests: 20   # 每个窗口允许的写请求数
+      window-seconds: 60 # 限流窗口，单位秒
+
 
 #日志相关配置
 logging:

--- a/backend/robot-service/src/test/java/com/iflytek/rpa/base/security/AtomAdminAccessGuardTest.java
+++ b/backend/robot-service/src/test/java/com/iflytek/rpa/base/security/AtomAdminAccessGuardTest.java
@@ -1,0 +1,66 @@
+package com.iflytek.rpa.base.security;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.iflytek.rpa.utils.exception.ServiceException;
+import com.iflytek.rpa.utils.response.ErrorCodeEnum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 覆盖 issue #790：原子能力写接口的令牌校验。
+ *
+ * <p>限流依赖 Redis，这里把窗口配置关掉，只验证令牌一侧的行为。</p>
+ */
+class AtomAdminAccessGuardTest {
+
+    private AtomAdminAccessGuard guard;
+
+    @BeforeEach
+    void setUp() {
+        guard = new AtomAdminAccessGuard();
+        ReflectionTestUtils.setField(guard, "maxRequests", 0);
+        ReflectionTestUtils.setField(guard, "windowSeconds", 0L);
+    }
+
+    @Test
+    void rejectsEveryWriteWhenNoTokenIsConfigured() {
+        ReflectionTestUtils.setField(guard, "adminToken", "");
+
+        assertThatThrownBy(() -> guard.checkWriteAccess(requestWithToken("anything")))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("code", ErrorCodeEnum.E_NO_POWER.getCode());
+    }
+
+    @Test
+    void rejectsRequestWithoutTheHeader() {
+        ReflectionTestUtils.setField(guard, "adminToken", "s3cret");
+
+        assertThatThrownBy(() -> guard.checkWriteAccess(new MockHttpServletRequest()))
+                .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    void rejectsWrongToken() {
+        ReflectionTestUtils.setField(guard, "adminToken", "s3cret");
+
+        assertThatThrownBy(() -> guard.checkWriteAccess(requestWithToken("wrong")))
+                .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    void acceptsMatchingToken() {
+        ReflectionTestUtils.setField(guard, "adminToken", "s3cret");
+
+        assertThatCode(() -> guard.checkWriteAccess(requestWithToken("s3cret"))).doesNotThrowAnyException();
+    }
+
+    private MockHttpServletRequest requestWithToken(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(AtomAdminAccessGuard.TOKEN_HEADER, token);
+        return request;
+    }
+}


### PR DESCRIPTION
## 📝 Pull Request 描述 | Description

给原子能力的三个写接口加上访问令牌校验与限流，替换 `CAtomController` 里的 `// todo 加密码，限流`。

### 🎯 变更类型 | Change Type

- [x] ✨ 新功能 | New Feature
- [x] 🔧 配置变更 | Configuration
- [x] ✅ 测试相关 | Tests

---

## 🔗 相关 Issue | Related Issues

- Closes #790

---

## 📋 变更内容 | Changes Made

### 问题比 issue 描述的更靠前一层

`/atom/add-common`、`/atom/update-common`、`/atom/save-atomics` 改写的是**整个平台共用**的原子能力定义（types / commonAdvancedParameter / atomicTree / atomics）。而网关对 `/api/robot/` 是**默认不做会话认证**的 —— `docker/volumes/nginx/default.conf` 里那段 `access_by_lua_file` 被注释掉了，注释写明是为了避免与认证服务循环调用：

```nginx
# 默认不对此路由进行认证，以避免认证服务自身的循环调用
location /api/robot/ {
    # if ($request_uri != "/api/robot/user/info") {
    #     access_by_lua_file lua/auth_handler.lua;
    # }
    proxy_pass http://robot-service;
```

所以这三个接口对能连到服务的任何人都是敞开的，不只是"缺少频率限制"。

### 主要变更 | Main Changes

新增 `AtomAdminAccessGuard`：

- **令牌校验**：请求头 `X-Atom-Admin-Token` 与 `atom.admin.token` 比对，用 `MessageDigest.isEqual` 做定长时间比较，避免逐字节比较的时序侧信道。
- **限流**：按客户端 IP 在 Redis 上做固定窗口计数，默认 60 秒 20 次，可配置。
- **顺序**：先限流后验令牌 —— 否则令牌可以被无限次尝试。
- **Redis 不可用时放行限流**（只记 warn）：令牌才是真正的门禁，限流是纵深防御，不该因为 Redis 抖动就锁死运维操作。
- 计数器写入后必定补 TTL（含 `getExpire < 0` 的兜底），避免某次 `expire` 失败把调用方永久挡在门外。

`/atom/save-atomics` 原本没有 todo 注释，但它同样是写接口，一并纳入。

只读接口（`/tree`、`getListByParentKey`、`getByVersionList`、`getLatestAtomByKey`、`getLatestAtomsByList`、`getLatestAllAtoms`）不受影响。

### ⚠️ 默认拒绝（Breaking）

`atom.admin.token` 未配置时，这三个写接口**一律拒绝**，而不是保持敞开。安全修复不应该以"没配置就等于放行"收尾。

仓库内没有任何代码调用这三个接口（前端 / engine / 脚本全都没有），所以影响面限于自行编写发布脚本的部署方 —— 配置一个环境变量即可：

```yaml
atom:
  admin:
    token: ${ATOM_ADMIN_TOKEN:}
    rate-limit:
      max-requests: 20
      window-seconds: 60
```

```bash
curl -X POST "$HOST/api/robot/atom/update-common" \
  -H "X-Atom-Admin-Token: $ATOM_ADMIN_TOKEN" \
  -H "Content-Type: application/json" -d @atom-common.json
```

如果维护者更希望"未配置时保持旧行为、只打告警"，我可以改成那样，但我倾向于默认关闭。

---

## ✅ 测试 | Testing

**本机没有 JDK / Maven，无法执行 `mvn test`，CI 是这批代码的第一次真实运行**，请以 CI 结果为准。

`AtomAdminAccessGuardTest`（新增）覆盖令牌一侧：未配置令牌时拒绝、缺请求头时拒绝、令牌错误时拒绝、令牌正确时放行。限流依赖 Redis，单测里通过把窗口配置置零关闭，未做集成验证。

---

## ⚠️ 风险 | Risk

- **限流按 IP 计数**，而 `X-Real-IP` / `X-Forwarded-For` 由代理写入；若入口未覆写这两个头，客户端可以伪造来源绕过限流。令牌不受此影响，因此这里只是纵深防御的削弱，不是门禁失效。
- 令牌是单一共享密钥，没有轮换与吊销机制。要做到 issue 里提的完整 API Key 体系（多密钥、可吊销、按调用方审计）是更大的工程，本 PR 先把敞开的写接口关上。
- 回滚：revert 本次提交，接口回到当前的无保护状态。
