### PR TITLE
docs(readme): add Related Projects section linking sibling Astron repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ If AstronRPA saves you time, consider giving it a ⭐ — it is the simplest way
   <img src="./docs/images/WeCom_Group.png" alt="WeChat Work Group" width="300">
 </div>
 
+## 🌐 Related Projects
+
+AstronRPA is part of the **[iFlytek Astron](https://github.com/iflytek)** open-source ecosystem. These sibling projects pair naturally with it:
+
+- **[Astron Agent](https://github.com/iflytek/astron-agent)** — Enterprise-grade agentic workflow platform. Call AstronRPA workflow nodes from Astron Agent (and use Agent workflows inside AstronRPA) for end-to-end automation.
+- **[SkillHub](https://github.com/iflytek/skillhub)** — Self-hosted, open-source agent skill registry to publish, version, and govern reusable skill packages across the Astron ecosystem.
+
 ## 📄 License
 
 This project is open source under the [Open Source License](LICENSE).


### PR DESCRIPTION
## What

Adds a **Related Projects** section to the README linking the sibling projects in the [iFlytek Astron](https://github.com/iflytek) open-source ecosystem.

## Why

[`iflytek/skillhub`](https://github.com/iflytek/skillhub)'s README already carries a `Related Projects` section pointing to this repo (and its sibling). This adds the reciprocal cross-reference so users landing here can discover the rest of the ecosystem, with a one-line description of the **real integration** between each pair — not a bare link list.

## Notes

- Docs-only change, no code impact.
- Wording and structure mirror the existing section in the SkillHub README.
