### PR TITLE
docs: self-host the star history chart from real stargazer data

### DIFF
--- a/.github/scripts/gen-star-history.mjs
+++ b/.github/scripts/gen-star-history.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Regenerate docs/star-history.svg from this repository's real stargazer history.
+//
+// Usage:
+//   GH_TOKEN=<token> node .github/scripts/gen-star-history.mjs [--repo owner/name] [--color '#2f7ed8'] [--out docs/star-history.svg]
+//
+// The repo defaults to $GITHUB_REPOSITORY (set by GitHub Actions). The token
+// defaults to $GH_TOKEN or $GITHUB_TOKEN. Because GitHub restricted the
+// stargazer-timestamp API to a repository's admins/collaborators (2026-06-30),
+// the token must be able to read this repo's stars. The script FAILS (exit 1)
+// without overwriting the existing SVG if it cannot read real dated stars, so a
+// permission problem never silently commits a broken chart.
+
+import { writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+function arg(name, def) {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : def;
+}
+
+const REPO = arg('--repo', process.env.GITHUB_REPOSITORY);
+const COLOR = arg('--color', '#2f7ed8');
+const OUT = arg('--out', 'docs/star-history.svg');
+const TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+
+if (!REPO) { console.error('No repo: pass --repo owner/name or set GITHUB_REPOSITORY'); process.exit(1); }
+if (!TOKEN) { console.error('No token: set GH_TOKEN or GITHUB_TOKEN'); process.exit(1); }
+
+const API = 'https://api.github.com';
+const HEADERS = {
+  'User-Agent': 'star-history-selfhost',
+  Authorization: 'Bearer ' + TOKEN,
+  Accept: 'application/vnd.github.star+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+
+async function getJson(path, tries = 6) {
+  let lastErr;
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(API + path, { headers: HEADERS });
+      if (res.ok) return res.json();
+      lastErr = new Error(res.status + ' ' + (await res.text()).slice(0, 160));
+    } catch (e) { lastErr = e; }
+    await new Promise(r => setTimeout(r, 800 * (i + 1)));
+  }
+  throw lastErr;
+}
+
+function niceMax(v) { const p = 10 ** Math.floor(Math.log10(v)); const n = v / p; return (n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10) * p; }
+function fmtDate(t) { const d = new Date(t); return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0'); }
+
+function renderSVG(pts, total, repo, color) {
+  const W = 840, H = 500, m = { top: 60, right: 150, bottom: 60, left: 74 };
+  const plotW = W - m.left - m.right, plotH = H - m.top - m.bottom;
+  let tMin = Infinity, tMax = -Infinity, yMax = 0;
+  for (const [t, y] of pts) { if (t < tMin) tMin = t; if (t > tMax) tMax = t; if (y > yMax) yMax = y; }
+  const yTop = niceMax(yMax);
+  const xOf = t => m.left + ((t - tMin) / (tMax - tMin)) * plotW;
+  const yOf = y => m.top + plotH - (y / yTop) * plotH;
+  const P = [];
+  P.push(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif">`);
+  P.push(`<rect width="${W}" height="${H}" fill="#ffffff"/>`);
+  P.push(`<text x="${W / 2}" y="34" text-anchor="middle" font-size="20" font-weight="600" fill="#24292f">Star History — ${repo}</text>`);
+  for (let i = 0; i <= 5; i++) { const val = yTop * i / 5, y = yOf(val); P.push(`<line x1="${m.left}" y1="${y.toFixed(1)}" x2="${m.left + plotW}" y2="${y.toFixed(1)}" stroke="#eaeef2"/>`); P.push(`<text x="${m.left - 10}" y="${(y + 4).toFixed(1)}" text-anchor="end" font-size="12" fill="#57606a">${Math.round(val).toLocaleString()}</text>`); }
+  for (let i = 0; i <= 6; i++) { const t = tMin + (tMax - tMin) * i / 6, x = xOf(t); P.push(`<line x1="${x.toFixed(1)}" y1="${m.top + plotH}" x2="${x.toFixed(1)}" y2="${(m.top + plotH + 5).toFixed(1)}" stroke="#8c959f"/>`); P.push(`<text x="${x.toFixed(1)}" y="${m.top + plotH + 22}" text-anchor="middle" font-size="12" fill="#57606a">${fmtDate(t)}</text>`); }
+  P.push(`<line x1="${m.left}" y1="${m.top}" x2="${m.left}" y2="${m.top + plotH}" stroke="#d0d7de" stroke-width="1.5"/>`);
+  P.push(`<line x1="${m.left}" y1="${m.top + plotH}" x2="${m.left + plotW}" y2="${m.top + plotH}" stroke="#d0d7de" stroke-width="1.5"/>`);
+  P.push(`<text transform="translate(22,${m.top + plotH / 2}) rotate(-90)" text-anchor="middle" font-size="13" fill="#57606a">GitHub Stars</text>`);
+  const d = pts.map(([t, y], i) => `${i ? 'L' : 'M'}${xOf(t).toFixed(1)},${yOf(y).toFixed(1)}`).join(' ');
+  P.push(`<path d="${d}" fill="none" stroke="${color}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>`);
+  const last = pts[pts.length - 1];
+  P.push(`<circle cx="${xOf(last[0]).toFixed(1)}" cy="${yOf(last[1]).toFixed(1)}" r="4" fill="${color}"/>`);
+  P.push(`<rect x="${m.left + plotW + 16}" y="${m.top + 6}" width="12" height="12" rx="2" fill="${color}"/>`);
+  P.push(`<text x="${m.left + plotW + 32}" y="${m.top + 17}" font-size="12" fill="#24292f">${repo.split('/')[1]}</text>`);
+  P.push(`<text x="${m.left + plotW + 32}" y="${m.top + 33}" font-size="12" font-weight="600" fill="${color}">${total.toLocaleString()} ★</text>`);
+  P.push('</svg>');
+  return P.join('\n');
+}
+
+const meta = await getJson(`/repos/${REPO}`);
+const total = meta.stargazers_count;
+if (!total || total < 2) { console.error('Repo has too few stars to chart'); process.exit(1); }
+
+const step = Math.max(1, Math.ceil(total / 70));
+const ks = [];
+for (let k = 1; k <= total; k += step) ks.push(k);
+if (ks[ks.length - 1] !== total) ks.push(total);
+
+const pts = [];
+for (const k of ks) {
+  const arrK = await getJson(`/repos/${REPO}/stargazers?per_page=1&page=${k}`);
+  const at = arrK && arrK[0] && arrK[0].starred_at;
+  if (at) pts.push([Date.parse(at), k]);
+}
+
+// Validate: the token must have returned real dated stars. Refuse to overwrite
+// the committed chart with garbage if access is restricted.
+if (pts.length < Math.min(ks.length, 5) || pts.length < ks.length * 0.8) {
+  console.error(`Only ${pts.length}/${ks.length} sampled stars had a starred_at timestamp. ` +
+    `The token likely lacks stargazer access for ${REPO} (GitHub restricts this to ` +
+    `admins/collaborators). Not overwriting ${OUT}.`);
+  process.exit(1);
+}
+
+writeFileSync(OUT, renderSVG(pts, total, REPO, COLOR));
+console.log(`Wrote ${OUT} — ${total.toLocaleString()} stars, ${pts.length} points.`);

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,40 @@
+name: Refresh star history chart
+
+on:
+  schedule:
+    - cron: '0 3 1 * *'   # 03:00 UTC on the 1st of each month
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Regenerate docs/star-history.svg
+        env:
+          # The repo-scoped GITHUB_TOKEN can read this repository's stars.
+          # If it is ever insufficient, set a STAR_HISTORY_TOKEN secret
+          # (a PAT that can read this repo) and it will be used instead.
+          GH_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN || github.token }}
+        run: node .github/scripts/gen-star-history.mjs --color '#eb7b04'
+      - name: Commit if the chart changed
+        run: |
+          if git diff --quiet -- docs/star-history.svg; then
+            echo "Star history chart unchanged."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add docs/star-history.svg
+          git commit -s -m 'chore: refresh star history chart'
+          git push

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We welcome any form of contribution! Please check [Contributing Guide](CONTRIBUT
 If AstronRPA saves you time, consider giving it a ⭐ — it is the simplest way to support the project and helps other automation builders discover it.
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-rpa&type=Date" alt="Star History Chart" width="600">
+  <img src="docs/star-history.svg" alt="Star History Chart" width="600">
 </div>
 
 ## 💖 Sponsorship

--- a/README.zh.md
+++ b/README.zh.md
@@ -200,7 +200,7 @@ docker compose ps
 如果 AstronRPA 帮你省下了时间，欢迎点一个 ⭐——这是支持项目最简单的方式，也能让更多自动化开发者发现它。
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=iflytek/astron-rpa&type=Date" alt="Star 历史图表" width="600">
+  <img src="docs/star-history.svg" alt="Star 历史图表" width="600">
 </div>
 
 ## 💖 赞助支持

--- a/docs/star-history.svg
+++ b/docs/star-history.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 500" width="840" height="500" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif">
+<rect width="840" height="500" fill="#ffffff"/>
+<text x="420" y="34" text-anchor="middle" font-size="20" font-weight="600" fill="#24292f">Star History — iflytek/astron-rpa</text>
+<line x1="74" y1="440.0" x2="690" y2="440.0" stroke="#eaeef2"/>
+<text x="64" y="444.0" text-anchor="end" font-size="12" fill="#57606a">0</text>
+<line x1="74" y1="364.0" x2="690" y2="364.0" stroke="#eaeef2"/>
+<text x="64" y="368.0" text-anchor="end" font-size="12" fill="#57606a">2,000</text>
+<line x1="74" y1="288.0" x2="690" y2="288.0" stroke="#eaeef2"/>
+<text x="64" y="292.0" text-anchor="end" font-size="12" fill="#57606a">4,000</text>
+<line x1="74" y1="212.0" x2="690" y2="212.0" stroke="#eaeef2"/>
+<text x="64" y="216.0" text-anchor="end" font-size="12" fill="#57606a">6,000</text>
+<line x1="74" y1="136.0" x2="690" y2="136.0" stroke="#eaeef2"/>
+<text x="64" y="140.0" text-anchor="end" font-size="12" fill="#57606a">8,000</text>
+<line x1="74" y1="60.0" x2="690" y2="60.0" stroke="#eaeef2"/>
+<text x="64" y="64.0" text-anchor="end" font-size="12" fill="#57606a">10,000</text>
+<line x1="74.0" y1="440" x2="74.0" y2="445.0" stroke="#8c959f"/>
+<text x="74.0" y="462" text-anchor="middle" font-size="12" fill="#57606a">2025-09</text>
+<line x1="176.7" y1="440" x2="176.7" y2="445.0" stroke="#8c959f"/>
+<text x="176.7" y="462" text-anchor="middle" font-size="12" fill="#57606a">2025-11</text>
+<line x1="279.3" y1="440" x2="279.3" y2="445.0" stroke="#8c959f"/>
+<text x="279.3" y="462" text-anchor="middle" font-size="12" fill="#57606a">2026-01</text>
+<line x1="382.0" y1="440" x2="382.0" y2="445.0" stroke="#8c959f"/>
+<text x="382.0" y="462" text-anchor="middle" font-size="12" fill="#57606a">2026-03</text>
+<line x1="484.7" y1="440" x2="484.7" y2="445.0" stroke="#8c959f"/>
+<text x="484.7" y="462" text-anchor="middle" font-size="12" fill="#57606a">2026-05</text>
+<line x1="587.3" y1="440" x2="587.3" y2="445.0" stroke="#8c959f"/>
+<text x="587.3" y="462" text-anchor="middle" font-size="12" fill="#57606a">2026-06</text>
+<line x1="690.0" y1="440" x2="690.0" y2="445.0" stroke="#8c959f"/>
+<text x="690.0" y="462" text-anchor="middle" font-size="12" fill="#57606a">2026-08</text>
+<line x1="74" y1="60" x2="74" y2="440" stroke="#d0d7de" stroke-width="1.5"/>
+<line x1="74" y1="440" x2="690" y2="440" stroke="#d0d7de" stroke-width="1.5"/>
+<text transform="translate(22,250) rotate(-90)" text-anchor="middle" font-size="13" fill="#57606a">GitHub Stars</text>
+<path d="M74.0,440.0 L109.0,436.9 L124.1,433.9 L127.3,430.8 L128.7,427.8 L129.8,424.8 L131.2,421.7 L132.5,418.7 L133.6,415.6 L134.5,412.6 L135.7,409.6 L136.7,406.5 L137.8,403.5 L138.7,400.4 L139.9,397.4 L141.0,394.4 L141.9,391.3 L142.8,388.3 L143.9,385.2 L145.0,382.2 L146.7,379.2 L148.2,376.1 L149.8,373.1 L149.9,370.0 L149.9,367.0 L151.4,364.0 L153.1,360.9 L160.4,357.9 L167.9,354.8 L176.6,351.8 L180.7,348.8 L189.2,345.7 L196.9,342.7 L207.3,339.6 L215.5,336.6 L222.8,333.6 L232.9,330.5 L242.0,327.5 L252.9,324.4 L271.3,321.4 L285.5,318.4 L301.5,315.3 L315.8,312.3 L329.2,309.2 L346.6,306.2 L361.8,303.2 L377.1,300.1 L393.3,297.1 L402.4,294.0 L407.8,291.0 L419.3,288.0 L428.9,284.9 L433.3,281.9 L440.5,278.8 L446.2,275.8 L451.9,272.8 L471.7,269.7 L482.9,266.7 L483.0,263.6 L508.5,260.6 L518.3,257.6 L629.9,254.5 L630.0,251.5 L630.2,248.4 L631.1,245.4 L631.4,242.4 L631.6,239.3 L632.4,236.3 L633.7,233.2 L638.9,230.2 L690.0,227.7" fill="none" stroke="#eb7b04" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="690.0" cy="227.7" r="4" fill="#eb7b04"/>
+<rect x="706" y="66" width="12" height="12" rx="2" fill="#eb7b04"/>
+<text x="722" y="77" font-size="12" fill="#24292f">astron-rpa</text>
+<text x="722" y="93" font-size="12" font-weight="600" fill="#eb7b04">5,588 ★</text>
+</svg>


### PR DESCRIPTION
## Summary

The Star History chart in the READMEs currently renders an **error image** rather than a chart. As of 2026-06-30 GitHub restricted the stargazer-*timestamp* API to a repository's admins/collaborators, so `api.star-history.com` can no longer read this repo's star dates and returns a "GitHub restricted access to star data" placeholder.

This PR fixes it by **self-hosting** the chart:

- Adds `docs/star-history.svg`, generated from this repository's **real stargazer history** (5,588★ at time of writing).
- Points `README.md` and `README.zh.md` at `docs/star-history.svg` instead of the external service.

## Why self-host rather than swap to another chart service

It keeps README rendering under the project's own control instead of an unvetted third-party image host — the SVG is plain, versioned in-repo, and also renders where GitHub's image proxy doesn't apply (mirrors, package pages, IDEs).

## Notes

- The SVG is a point-in-time **snapshot**. Happy to follow up with a small scheduled GitHub Actions workflow to regenerate it periodically (a repo-scoped `GITHUB_TOKEN` in Actions can read the stargazer timestamps).
- Only the two `<img src>` lines changed in the READMEs; nothing else was touched.---

### Update: now self-refreshing

This PR also adds `.github/workflows/star-history.yml` (monthly + manual `workflow_dispatch`) and `.github/scripts/gen-star-history.mjs`, so the chart stays current without manual work:

- The generator uses **Node built-ins only** (no dependencies) and reads the repo's real stargazer timestamps via the workflow's `GITHUB_TOKEN`. It **fails closed** — if the token can't read dated stars, it errors and leaves the committed SVG untouched, so a permission problem never commits a broken chart.
- The workflow **commits only when the chart actually changes**, with a DCO sign-off from `github-actions[bot]`.
- Note: this step pushes to the default branch. If that branch is protected against the Actions bot, either allow it or set a `STAR_HISTORY_TOKEN` PAT secret (the workflow already prefers it when present). Happy to switch it to a PR-opening flow instead if you'd rather review each refresh.