### PR TITLE
修复 MCP 鉴权语义与执行记录用户隔离

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -47,6 +47,14 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: uv run --project engine --dev ruff format ./engine --check
 
+      - name: Install scheduler test dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: uv sync --project engine/servers/astronverse-scheduler --dev --frozen
+
+      - name: Run scheduler tests
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: uv run --project engine/servers/astronverse-scheduler --dev --no-sync pytest engine/servers/astronverse-scheduler/tests
+
   java-style:
     name: Java Style
     runs-on: ubuntu-latest

--- a/backend/openapi-service/.env.example
+++ b/backend/openapi-service/.env.example
@@ -4,3 +4,4 @@ DATABASE_URL="mysql+aiomysql://{username}:{password}@localhost:3306/rpa?charset=
 DATABASE_USERNAME="root"
 DATABASE_PASSWORD="123456"
 REDIS_URL="redis://123456@localhost:6379/0"
+MCP_ALLOW_QUERY_API_KEY=false

--- a/backend/openapi-service/README.md
+++ b/backend/openapi-service/README.md
@@ -132,6 +132,25 @@ rpa-openapi-service/
 ### 5. MCP Protocol Support (`/mcp`)
 - **Model Context Protocol** - Support for AI model interaction with workflows
 - **Streaming HTTP Processing** - Support for streaming data transmission and processing
+- **API Key Authentication** - Supports Bearer and `X-API-Key` request headers
+
+#### MCP Authentication
+
+Bearer authentication is recommended for production:
+
+```http
+Authorization: Bearer <API_KEY>
+```
+
+The dedicated header is also supported:
+
+```http
+X-API-Key: <API_KEY>
+```
+
+URL query credentials (`?key=`) are rejected by default so credentials do not enter browser history or proxy logs.
+Set `MCP_ALLOW_QUERY_API_KEY=true` only while migrating legacy clients. A request must use exactly one credential
+source. Missing, malformed, invalid, or revoked credentials return HTTP 401.
 
 ## 🚀 Quick Start
 
@@ -169,6 +188,9 @@ REDIS_URL=redis://localhost:6379/0
 
 # Application name
 APP_NAME="RPA OpenAPI Service"
+
+# Enable temporarily only while migrating legacy MCP clients
+MCP_ALLOW_QUERY_API_KEY=false
 ```
 
 ### 3. Start Service

--- a/backend/openapi-service/README.zh.md
+++ b/backend/openapi-service/README.zh.md
@@ -132,6 +132,25 @@ rpa-openapi-service/
 ### 5. MCP 协议支持 (`/mcp`)
 - **Model Context Protocol** - 支持 AI 模型与工作流的交互
 - **流式 HTTP 处理** - 支持流式数据传输和处理
+- **API Key 鉴权** - 支持 Bearer 和 `X-API-Key` 请求头
+
+#### MCP 鉴权
+
+生产环境推荐使用 Bearer：
+
+```http
+Authorization: Bearer <API_KEY>
+```
+
+也可以使用独立请求头：
+
+```http
+X-API-Key: <API_KEY>
+```
+
+默认不接受 URL 查询参数中的 `?key=`，避免密钥进入浏览器历史和代理日志。仅在迁移旧客户端时临时设置
+`MCP_ALLOW_QUERY_API_KEY=true`。同一请求只能使用一种凭据来源；缺失、格式错误、无效或已吊销的密钥返回
+HTTP 401。
 
 ## 🚀 快速开始
 
@@ -169,6 +188,9 @@ REDIS_URL=redis://localhost:6379/0
 
 # 应用名称
 APP_NAME="My New Service"
+
+# 仅迁移旧 MCP 客户端时临时开启，生产环境保持 false
+MCP_ALLOW_QUERY_API_KEY=false
 ```
 
 ### 3. 启动服务

--- a/backend/openapi-service/api.yaml
+++ b/backend/openapi-service/api.yaml
@@ -116,9 +116,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Execution'
+                $ref: '#/components/schemas/StandardResponse'
         '404':
           description: 执行记录不存在
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
   /api-keys:
     get:
       tags: [api-key]
@@ -168,6 +172,18 @@ paths:
           description: 成功删除 API Key
 components:
   schemas:
+    StandardResponse:
+      type: object
+      required: [code, msg]
+      properties:
+        code:
+          type: string
+          enum: ['0000', '5001']
+        msg:
+          type: string
+        data:
+          nullable: true
+          type: object
     Workflow:
       type: object
       properties:

--- a/backend/openapi-service/app/config.py
+++ b/backend/openapi-service/app/config.py
@@ -14,6 +14,10 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     LOG_DIR: str = "/var/log/rpa-openapi"
 
+    # URL credentials are disabled by default because query strings commonly
+    # appear in browser history and proxy access logs.
+    MCP_ALLOW_QUERY_API_KEY: bool = False
+
     model_config = SettingsConfigDict(
         env_file=None,
         case_sensitive=False,

--- a/backend/openapi-service/app/dependencies/__init__.py
+++ b/backend/openapi-service/app/dependencies/__init__.py
@@ -1,6 +1,5 @@
 import os
 from datetime import datetime
-from typing import Dict, List, Optional
 
 from fastapi import Depends, Header, HTTPException, Security, status  # Added status
 from fastapi.security import APIKeyHeader
@@ -110,34 +109,6 @@ async def verify_getkey_bearer_token(
         )
 
     return bearer_token
-
-
-def extract_api_key_from_request(ctx) -> Optional[str]:
-    """
-    从请求上下文中提取API_KEY
-    MCP使用
-    """
-
-    # 尝试多种方式获取查询参数
-    query_params = ctx.request.query_params
-
-    if query_params:
-        # 如果是字典类型
-        if isinstance(query_params, dict):
-            return query_params.get("key")
-
-        # 如果是QueryParams对象（Starlette）
-        if hasattr(query_params, "get"):
-            return query_params.get("key")
-
-        # 如果是字符串类型的查询字符串
-        if isinstance(query_params, str):
-            from urllib.parse import parse_qs
-
-            parsed = parse_qs(query_params)
-            key_values = parsed.get("key", [])
-            return key_values[0] if key_values else None
-    return None
 
 
 async def get_user_id_from_api_key(

--- a/backend/openapi-service/app/routers/executions.py
+++ b/backend/openapi-service/app/routers/executions.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Path, Query
+from fastapi import APIRouter, Depends, Path, Query, Response, status
 
 from app.dependencies import get_execution_service, get_user_id_from_api_key
 from app.logger import get_logger
@@ -53,6 +53,7 @@ async def get_executions(
     description="查询工作流执行的状态和结果",
 )
 async def get_execution(
+    response: Response,
     execution_id: str = Path(..., description="执行记录ID"),
     user_id: str = Depends(get_user_id_from_api_key),
     service: ExecutionService = Depends(get_execution_service),
@@ -61,6 +62,7 @@ async def get_execution(
     try:
         execution = await service.get_execution(execution_id, user_id)
         if not execution:
+            response.status_code = status.HTTP_404_NOT_FOUND
             return StandardResponse(
                 code=ResCode.ERR,
                 msg=f"Execution with ID {execution_id} not found",

--- a/backend/openapi-service/app/routers/streamable_mcp.py
+++ b/backend/openapi-service/app/routers/streamable_mcp.py
@@ -5,11 +5,12 @@ from mcp.server.lowlevel import Server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.types import Receive, Scope, Send
 
+from app.config import get_settings
 from app.logger import get_logger
+from app.security.mcp_auth import MCPAPIKeyAuthMiddleware
+from app.services.streamable_mcp import ToolsConfig
 
 logger = get_logger(__name__)
-from app.dependencies import extract_api_key_from_request
-from app.services.streamable_mcp import ToolsConfig
 
 app = Server("iflyrpa-mcp")
 
@@ -25,22 +26,22 @@ session_manager = StreamableHTTPSessionManager(
 )
 
 
+def get_authenticated_user_id(ctx) -> str:
+    """Read the user identity established by the HTTP authentication boundary."""
+    if ctx.request is None:
+        raise RuntimeError("MCP request context is unavailable")
+
+    user_id = getattr(ctx.request.state, "mcp_user_id", None)
+    if not user_id:
+        raise RuntimeError("MCP request is missing its authenticated user")
+    return str(user_id)
+
+
 @app.call_tool()
 async def call_tool(name: str, arguments: dict) -> list[types.ContentBlock]:
     ctx = app.request_context
-
-    # 从URL参数获取API_KEY
-    api_key = extract_api_key_from_request(ctx)
-    user_id = await tools_config.get_uid_from_raw_key(api_key)
+    user_id = get_authenticated_user_id(ctx)
     logger.info(f"[call_tool] user_id: {user_id}")
-    if not user_id:
-        await ctx.session.send_log_message(
-            level="error",
-            data=f"No user found for API key: {api_key}",
-            logger="permission_check",
-            related_request_id=ctx.request_id,
-        )
-        raise Exception("未找到用户: No user found for API key")
 
     # 使用 ToolsConfig 执行工作流
     result = await tools_config.execute_workflow_by_name(name, user_id, arguments)
@@ -74,23 +75,7 @@ async def call_tool(name: str, arguments: dict) -> list[types.ContentBlock]:
 async def list_tools() -> list[types.Tool]:
     # 获取请求上下文信息
     ctx = app.request_context
-
-    # 从URL参数获取API_KEY
-    api_key = extract_api_key_from_request(ctx)
-    if not api_key:
-        return []
-
-    user_id = await tools_config.get_uid_from_raw_key(api_key)
-    if not user_id:
-        # 记录权限检查失败
-        if hasattr(ctx, "session"):
-            await ctx.session.send_log_message(
-                level="warning",
-                data=f"No user found for API key: {api_key}",
-                logger="permission_check",
-                related_request_id=ctx.request_id,
-            )
-        return []
+    user_id = get_authenticated_user_id(ctx)
 
     # 获取用户可用的工具
     allowed_tools = await tools_config.get_tools_for_user(user_id)
@@ -107,5 +92,12 @@ async def list_tools() -> list[types.Tool]:
     return allowed_tools
 
 
+mcp_auth_app = MCPAPIKeyAuthMiddleware(
+    session_manager.handle_request,
+    tools_config.get_uid_from_raw_key,
+    allow_query_api_key=get_settings().MCP_ALLOW_QUERY_API_KEY,
+)
+
+
 async def handle_streamable_http(scope: Scope, receive: Receive, send: Send) -> None:
-    await session_manager.handle_request(scope, receive, send)
+    await mcp_auth_app(scope, receive, send)

--- a/backend/openapi-service/app/security/__init__.py
+++ b/backend/openapi-service/app/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security helpers for externally exposed OpenAPI transports."""

--- a/backend/openapi-service/app/security/mcp_auth.py
+++ b/backend/openapi-service/app/security/mcp_auth.py
@@ -1,0 +1,113 @@
+import json
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+from urllib.parse import parse_qs
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+APIKeyValidator = Callable[[str], Awaitable[str | None]]
+
+
+class MCPAuthenticationError(ValueError):
+    """Raised when an MCP request does not contain one unambiguous credential."""
+
+
+def _get_header_values(scope: Mapping[str, Any], name: bytes) -> list[str]:
+    values = []
+    for raw_name, raw_value in scope.get("headers", []):
+        if raw_name.lower() == name:
+            values.append(raw_value.decode("latin-1").strip())
+    return values
+
+
+def extract_mcp_api_key(scope: Mapping[str, Any], *, allow_query_api_key: bool = False) -> str:
+    """Extract exactly one MCP API key from the supported credential locations."""
+    credentials: list[str] = []
+
+    authorization_values = _get_header_values(scope, b"authorization")
+    if len(authorization_values) > 1:
+        raise MCPAuthenticationError("Multiple Authorization headers are not allowed")
+    if authorization_values:
+        parts = authorization_values[0].split()
+        if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
+            raise MCPAuthenticationError("Invalid Authorization header")
+        credentials.append(parts[1])
+
+    api_key_header_values = _get_header_values(scope, b"x-api-key")
+    if len(api_key_header_values) > 1 or (api_key_header_values and not api_key_header_values[0]):
+        raise MCPAuthenticationError("Invalid X-API-Key header")
+    if api_key_header_values:
+        credentials.append(api_key_header_values[0])
+
+    query_values = parse_qs(
+        scope.get("query_string", b"").decode("latin-1"),
+        keep_blank_values=True,
+    ).get("key", [])
+    if query_values:
+        if not allow_query_api_key:
+            raise MCPAuthenticationError("Query parameter API keys are disabled")
+        if len(query_values) != 1 or not query_values[0].strip():
+            raise MCPAuthenticationError("Invalid query parameter API key")
+        credentials.append(query_values[0].strip())
+
+    if len(credentials) != 1:
+        raise MCPAuthenticationError("Exactly one API key credential is required")
+
+    return credentials[0]
+
+
+class MCPAPIKeyAuthMiddleware:
+    """Authenticate every Streamable HTTP request before it reaches the MCP SDK."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        validator: APIKeyValidator,
+        *,
+        allow_query_api_key: bool = False,
+    ) -> None:
+        self.app = app
+        self.validator = validator
+        self.allow_query_api_key = allow_query_api_key
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            api_key = extract_mcp_api_key(
+                scope,
+                allow_query_api_key=self.allow_query_api_key,
+            )
+            user_id = await self.validator(api_key)
+        except MCPAuthenticationError:
+            await self._send_error(send, 401, "Invalid authentication credentials", authenticate=True)
+            return
+        except Exception:
+            logger.exception("MCP API key validation failed")
+            await self._send_error(send, 503, "Authentication service unavailable")
+            return
+
+        if not user_id:
+            await self._send_error(send, 401, "Invalid authentication credentials", authenticate=True)
+            return
+
+        scope.setdefault("state", {})["mcp_user_id"] = str(user_id)
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    async def _send_error(send: Send, status_code: int, detail: str, *, authenticate: bool = False) -> None:
+        body = json.dumps({"detail": detail}).encode("utf-8")
+        headers = [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode("ascii")),
+        ]
+        if authenticate:
+            headers.append((b"www-authenticate", b"Bearer"))
+
+        await send({"type": "http.response.start", "status": status_code, "headers": headers})
+        await send({"type": "http.response.body", "body": body})

--- a/backend/openapi-service/app/services/api_key.py
+++ b/backend/openapi-service/app/services/api_key.py
@@ -27,7 +27,7 @@ class ApiKeyService:
             if keys:
                 await self.redis.delete(*keys)
 
-    async def create_api_key(self, api_key_data: ApiKeyCreate, user_id: str) -> OpenAPIDB:
+    async def create_api_key(self, api_key_data: ApiKeyCreate, user_id: str) -> str:
         """创建新API Key"""
 
         # 生成唯一ID和密钥

--- a/backend/openapi-service/app/services/execution.py
+++ b/backend/openapi-service/app/services/execution.py
@@ -47,13 +47,19 @@ class ExecutionService:
 
         return execution
 
-    async def get_execution(self, execution_id: str, user_id: str | None = None) -> Optional[Execution]:
-        """获取执行记录"""
-        query = select(Execution).where(Execution.id == execution_id)
+    async def get_execution(self, execution_id: str, user_id: str) -> Optional[Execution]:
+        """获取属于指定用户的执行记录。"""
+        query = select(Execution).where(
+            Execution.id == execution_id,
+            Execution.user_id == user_id,
+        )
 
-        # 不校验user_id
-        # if user_id is not None:
-        #     query = query.where(Execution.user_id == user_id)
+        result = await self.db.execute(query)
+        return result.scalars().first()
+
+    async def get_execution_internal(self, execution_id: str) -> Optional[Execution]:
+        """供后台执行流程按 ID 获取记录，不作为外部授权边界。"""
+        query = select(Execution).where(Execution.id == execution_id)
 
         result = await self.db.execute(query)
         return result.scalars().first()
@@ -136,7 +142,7 @@ class ExecutionService:
             await self.db.commit()
 
             # 返回更新后的执行记录
-            return await self.get_execution(execution_id)
+            return await self.get_execution_internal(execution_id)
         except Exception as e:
             # 如果更新失败，回滚事务并记录错误
             try:
@@ -159,8 +165,11 @@ class ExecutionService:
 
         # 确保执行记录已经提交到数据库
         await self.db.commit()
-        logger.info("Created execution %s and committed to database", execution.id)
-        logger.info("[execute_workflow] user_id: %s ", user_id)
+        logger.info(
+            "Created execution %s for authenticated user %s and committed to database",
+            execution.id,
+            execution.user_id,
+        )
 
         # 保存 execution_id，后续需要用
         execution_id = execution.id
@@ -171,28 +180,28 @@ class ExecutionService:
 
         if wait:
             # 同步执行模式 - 使用新的数据库会话，避免长时间占用连接
-            await self._run_workflow_with_new_session_sync(execution_id, workflow_timeout, user_id)
+            await self._run_workflow_with_new_session_sync(execution_id, workflow_timeout)
 
             # 使用原会话重新获取最新状态
             await self.db.refresh(execution)
         else:
             # 异步执行模式，后台执行（不等待结果）
-            asyncio.create_task(self._run_workflow_with_new_session(execution_id, workflow_timeout, user_id))
+            asyncio.create_task(self._run_workflow_with_new_session(execution_id, workflow_timeout))
 
         return execution
 
-    async def _run_workflow(self, execution_id: str, workflow_timeout: int = 36000, user_id: str = "") -> None:
+    async def _run_workflow(self, execution_id: str, workflow_timeout: int = 36000) -> None:
         """运行工作流执行逻辑"""
         try:
-            # 获取执行记录
-            execution = await self.get_execution(execution_id)
+            # 重新读取已提交的执行记录。此处的 user_id 是派发目标的唯一可信来源，
+            # 避免调用方另传身份而造成审计记录与实际执行主体不一致。
+            execution = await self.get_execution_internal(execution_id)
             if not execution:
                 logger.info("Execution not found for execution_id: %s", execution_id)
                 raise Exception(f"Execution not found for execution_id: {execution_id}")
-            logger.info("[_run_workflow] user_id: %s ", user_id)
             # 设置超时
             await asyncio.wait_for(
-                self._execute_workflow_logic(execution, user_id),
+                self._execute_workflow_logic(execution),
                 timeout=workflow_timeout,
             )
         except TimeoutError:
@@ -202,20 +211,20 @@ class ExecutionService:
         except Exception as e:
             await self.update_execution_status(execution_id, ExecutionStatus.FAILED.value, error=str(e))
 
-    async def _run_workflow_with_new_session_sync(self, execution_id: str, workflow_timeout: int, user_id: str) -> None:
+    async def _run_workflow_with_new_session_sync(self, execution_id: str, workflow_timeout: int) -> None:
         """使用新的数据库会话运行工作流（同步版本，会抛出异常）"""
         async with AsyncSessionLocal() as db:
             execution_service = ExecutionService(db, self.redis)
             logger.info("Running workflow execution %s", execution_id)
-            await execution_service._run_workflow(execution_id, workflow_timeout, user_id)
+            await execution_service._run_workflow(execution_id, workflow_timeout)
 
-    async def _run_workflow_with_new_session(self, execution_id: str, workflow_timeout: int, user_id: str) -> None:
+    async def _run_workflow_with_new_session(self, execution_id: str, workflow_timeout: int) -> None:
         """使用新的数据库会话运行工作流（异步版本，不抛出异常）"""
         async with AsyncSessionLocal() as db:
             try:
                 execution_service = ExecutionService(db, self.redis)
                 logger.info("Running background workflow execution %s", execution_id)
-                await execution_service._run_workflow(execution_id, workflow_timeout, user_id)
+                await execution_service._run_workflow(execution_id, workflow_timeout)
             except Exception as e:
                 # 记录错误日志
                 logger.exception("Error in background workflow execution %s", execution_id)
@@ -231,7 +240,7 @@ class ExecutionService:
                 except Exception as update_error:
                     logger.exception("Failed to update execution status for %s", execution_id)
 
-    async def _execute_workflow_logic(self, execution: Execution, user_id: str) -> None:
+    async def _execute_workflow_logic(self, execution: Execution) -> None:
         """
         实现工作流执行的实际逻辑
         这里是一个示例，实际项目中需要根据不同工作流实现不同的逻辑
@@ -248,8 +257,14 @@ class ExecutionService:
 
             websocket_service = await get_ws_service()
             logger.info("Got websocket service for execution %s", execution.id)
-            logger.info("execution.user_id: %s", execution.user_id)
-            logger.info("input user_id: %s", user_id)
+
+            if not execution.user_id:
+                raise ValueError(f"Execution {execution.id} has no authenticated user identity")
+            logger.info(
+                "Dispatching execution %s for recorded user %s",
+                execution.id,
+                execution.user_id,
+            )
 
             wait = asyncio.Event()
             res = {}
@@ -300,7 +315,7 @@ class ExecutionService:
                 channel="remote",
                 key="run",
                 uuid="$root$",
-                send_uuid=f"{user_id}",
+                send_uuid=str(execution.user_id),
                 need_reply=True,
                 data=executor_data,
             ).init()

--- a/backend/openapi-service/app/services/streamable_mcp.py
+++ b/backend/openapi-service/app/services/streamable_mcp.py
@@ -76,11 +76,11 @@ class ToolsConfig:
                 if APIKeyUtils.verify_api_key(api_key, hashed_key):
                     return str(key.user_id)
             return None
-        except Exception as e:
+        except Exception:
             logger.exception("Error getting user ID from API key")
             if db:
                 await db.rollback()
-            return None
+            raise
         finally:
             # 确保数据库会话被关闭
             if db:

--- a/backend/openapi-service/tests/conftest.py
+++ b/backend/openapi-service/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from redis.asyncio import ConnectionPool, Redis
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -147,9 +148,20 @@ async def create_api_key(user_id: str, test_get_db, test_get_redis=None):
 
     # 创建 API Key
     api_key_data = ApiKeyCreate(name=f"Test API Key {random.randint(1000, 9999)}")
-    api_key = await service.create_api_key(api_key_data, user_id)
+    raw_api_key = await service.create_api_key(api_key_data, user_id)
 
-    return {"id": api_key.id, "key": api_key.key}
+    from app.models.api_key import OpenAPIDB
+
+    result = await test_get_db.execute(
+        select(OpenAPIDB).where(
+            OpenAPIDB.user_id == user_id,
+            OpenAPIDB.prefix == raw_api_key[:8],
+            OpenAPIDB.name == api_key_data.name,
+        )
+    )
+    api_key_record = result.scalars().one()
+
+    return {"id": api_key_record.id, "key": raw_api_key}
 
 
 async def destroy_api_key(user_id: str, key_data: dict, test_get_db, test_get_redis=None):

--- a/backend/openapi-service/tests/routers/test_workflows.py
+++ b/backend/openapi-service/tests/routers/test_workflows.py
@@ -168,4 +168,5 @@ async def test_get_nonexistent_execution(client: AsyncClient, api_key):
     non_existent_id = f"non-existent-{random.randint(10000, 99999)}"
     response = await client.get(f"/executions/{non_existent_id}", headers=headers)
     assert response.status_code == 404
-    assert "不存在" in response.json()["detail"] or "not found" in response.json()["detail"].lower()
+    assert response.json()["code"] == "5001"
+    assert "not found" in response.json()["msg"].lower()

--- a/backend/openapi-service/tests/test_execution_isolation.py
+++ b/backend/openapi-service/tests/test_execution_isolation.py
@@ -1,0 +1,237 @@
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Response
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("DATABASE_URL", "mysql+aiomysql://test:test@localhost:3306/test")
+os.environ.setdefault("DATABASE_USERNAME", "test")
+os.environ.setdefault("DATABASE_PASSWORD", "test")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+from app.models.workflow import Execution
+from app.routers.executions import get_execution as get_execution_route
+from app.schemas import ResCode
+from app.schemas.workflow import ExecutionCreate
+from app.services.execution import ExecutionService
+
+
+class AsyncSessionAdapter:
+    """Minimal async facade over a real in-memory SQLAlchemy session."""
+
+    def __init__(self, session):
+        self.session = session
+
+    async def execute(self, statement):
+        return self.session.execute(statement)
+
+    async def commit(self):
+        self.session.commit()
+
+    async def rollback(self):
+        self.session.rollback()
+
+
+def empty_scalar_result():
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = None
+    return result
+
+
+@pytest.mark.asyncio
+async def test_external_execution_lookup_filters_by_execution_and_user_id():
+    db = AsyncMock()
+    db.execute.return_value = empty_scalar_result()
+    service = ExecutionService(db)
+
+    execution = await service.get_execution("execution-owned-by-a", "user-b")
+
+    assert execution is None
+    statement = db.execute.await_args.args[0]
+    compiled = statement.compile()
+    assert "execution-owned-by-a" in compiled.params.values()
+    assert "user-b" in compiled.params.values()
+    assert "user_id" in str(statement.whereclause)
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_read_or_cancel_another_users_execution():
+    engine = create_engine("sqlite:///:memory:")
+    Execution.__table__.create(engine)
+
+    with Session(engine, expire_on_commit=False) as session:
+        session.add(
+            Execution(
+                id="execution-owned-by-a",
+                project_id="project-a",
+                user_id="user-a",
+                status="PENDING",
+            )
+        )
+        session.commit()
+        service = ExecutionService(AsyncSessionAdapter(session))
+
+        assert await service.get_execution("execution-owned-by-a", "user-a") is not None
+        assert await service.get_execution("execution-owned-by-a", "user-b") is None
+        assert await service.cancel_execution("execution-owned-by-a", "user-b") is False
+
+        stored_execution = session.get(Execution, "execution-owned-by-a")
+        assert stored_execution.status == "PENDING"
+
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cross_user_and_unknown_execution_have_the_same_404_response():
+    service = AsyncMock()
+    service.get_execution.return_value = None
+
+    cross_user_response = Response()
+    cross_user_body = await get_execution_route(
+        response=cross_user_response,
+        execution_id="execution-owned-by-a",
+        user_id="user-b",
+        service=service,
+    )
+
+    unknown_response = Response()
+    unknown_body = await get_execution_route(
+        response=unknown_response,
+        execution_id="unknown-execution",
+        user_id="user-b",
+        service=service,
+    )
+
+    assert cross_user_response.status_code == 404
+    assert unknown_response.status_code == 404
+    assert cross_user_body.code == unknown_body.code == ResCode.ERR
+    assert cross_user_body.data is unknown_body.data is None
+
+
+@pytest.mark.asyncio
+async def test_status_update_uses_internal_execution_lookup():
+    db = AsyncMock()
+    service = ExecutionService(db)
+    updated_execution = MagicMock()
+    service.get_execution_internal = AsyncMock(return_value=updated_execution)
+
+    result = await service.update_execution_status("execution-1", "RUNNING")
+
+    assert result is updated_execution
+    service.get_execution_internal.assert_awaited_once_with("execution-1")
+
+
+@pytest.mark.asyncio
+async def test_create_execution_pins_authenticated_user_to_record():
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    service = ExecutionService(db)
+
+    execution = await service.create_execution(
+        ExecutionCreate(project_id="project-1", params={"value": 1}),
+        "authenticated-user",
+    )
+
+    assert execution.user_id == "authenticated-user"
+    db.add.assert_called_once_with(execution)
+
+
+@pytest.mark.asyncio
+async def test_execute_workflow_does_not_forward_a_second_dispatch_identity(monkeypatch):
+    db = AsyncMock()
+    service = ExecutionService(db)
+    execution = Execution(
+        id="execution-1",
+        project_id="project-1",
+        user_id="authenticated-user",
+        status="PENDING",
+    )
+    service.create_execution = AsyncMock(return_value=execution)
+    service._run_workflow_with_new_session_sync = AsyncMock()
+    monkeypatch.setattr("app.services.execution.asyncio.sleep", AsyncMock())
+
+    await service.execute_workflow(
+        ExecutionCreate(project_id="project-1"),
+        "authenticated-user",
+        wait=True,
+        workflow_timeout=123,
+    )
+
+    service.create_execution.assert_awaited_once()
+    assert service.create_execution.await_args.args[1] == "authenticated-user"
+    service._run_workflow_with_new_session_sync.assert_awaited_once_with("execution-1", 123)
+
+
+@pytest.mark.asyncio
+async def test_background_runner_uses_identity_from_persisted_execution():
+    db = AsyncMock()
+    service = ExecutionService(db)
+    execution = Execution(
+        id="execution-1",
+        project_id="project-1",
+        user_id="recorded-user",
+        status="PENDING",
+    )
+    service.get_execution_internal = AsyncMock(return_value=execution)
+    service._execute_workflow_logic = AsyncMock()
+
+    await service._run_workflow("execution-1", workflow_timeout=123)
+
+    service.get_execution_internal.assert_awaited_once_with("execution-1")
+    service._execute_workflow_logic.assert_awaited_once_with(execution)
+
+
+@pytest.mark.asyncio
+async def test_websocket_dispatch_uses_only_recorded_execution_identity(monkeypatch):
+    db = AsyncMock()
+    service = ExecutionService(db)
+    service.update_execution_status = AsyncMock()
+    websocket_service = MagicMock()
+
+    async def reply_with_success(base_msg, timeout, callback):
+        callback(MagicMock(data={"code": "0000"}))
+
+    websocket_service.ws_manager.send_reply = AsyncMock(side_effect=reply_with_success)
+    monkeypatch.setattr(
+        "app.dependencies.get_ws_service",
+        AsyncMock(return_value=websocket_service),
+    )
+    execution = Execution(
+        id="execution-1",
+        project_id="project-1",
+        user_id="recorded-user",
+        status="PENDING",
+        parameters="{}",
+        exec_position="EXECUTOR",
+    )
+
+    await service._execute_workflow_logic(execution)
+
+    dispatched_message = websocket_service.ws_manager.send_reply.await_args.args[0]
+    assert dispatched_message.send_uuid == "recorded-user"
+    service.update_execution_status.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_websocket_dispatch_fails_closed_without_recorded_identity(monkeypatch):
+    service = ExecutionService(AsyncMock())
+    websocket_service = MagicMock()
+    websocket_service.ws_manager.send_reply = AsyncMock()
+    monkeypatch.setattr(
+        "app.dependencies.get_ws_service",
+        AsyncMock(return_value=websocket_service),
+    )
+    execution = Execution(
+        id="execution-without-user",
+        project_id="project-1",
+        user_id=None,
+        status="PENDING",
+    )
+
+    with pytest.raises(ValueError, match="has no authenticated user identity"):
+        await service._execute_workflow_logic(execution)
+
+    websocket_service.ws_manager.send_reply.assert_not_awaited()

--- a/backend/openapi-service/tests/test_mcp_auth.py
+++ b/backend/openapi-service/tests/test_mcp_auth.py
@@ -1,0 +1,390 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Mount
+
+from app import database
+from app.main import app as openapi_app
+from app.models.api_key import OpenAPIDB
+from app.routers.streamable_mcp import app as mcp_server
+from app.routers.streamable_mcp import tools_config
+from app.security.mcp_auth import MCPAPIKeyAuthMiddleware
+from app.services.streamable_mcp import ToolsConfig
+from app.utils.api_key import APIKeyUtils
+
+
+class AsyncSessionAdapter:
+    """Minimal async facade over a real in-memory SQLAlchemy session."""
+
+    def __init__(self, session):
+        self.session = session
+
+    async def execute(self, statement):
+        return self.session.execute(statement)
+
+    async def rollback(self):
+        self.session.rollback()
+
+    async def close(self):
+        self.session.close()
+
+
+async def empty_tools_app(scope, receive, send):
+    response = JSONResponse(
+        {
+            "tools": [],
+            "user_id": scope["state"]["mcp_user_id"],
+        }
+    )
+    await response(scope, receive, send)
+
+
+async def request_mcp(auth_app, *, headers=None, params=None):
+    transport = ASGITransport(app=auth_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post("/mcp", headers=headers, params=params)
+
+
+def make_asgi_http_client_factory(asgi_app):
+    @asynccontextmanager
+    async def asgi_http_client_factory(headers=None, timeout=None, auth=None):
+        transport = ASGITransport(app=asgi_app)
+        async with AsyncClient(transport=transport, headers=headers, timeout=timeout, auth=auth) as client:
+            yield client
+
+    return asgi_http_client_factory
+
+
+@pytest.mark.asyncio
+async def test_mcp_mount_rejects_missing_credentials_before_protocol_handling():
+    transport = ASGITransport(app=openapi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/mcp/")
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_mcp_mount_rejects_query_key_with_default_configuration():
+    transport = ASGITransport(app=openapi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/mcp/", params={"key": "legacy-key"})
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_mcp_missing_credentials_returns_401():
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(auth_app)
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mcp_bearer_authenticates_before_returning_empty_tools():
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(
+        auth_app,
+        headers={"Authorization": "Bearer valid-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"tools": [], "user_id": "user-1"}
+    validator.assert_awaited_once_with("valid-key")
+
+
+@pytest.mark.asyncio
+async def test_mcp_x_api_key_authenticates():
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(auth_app, headers={"X-API-Key": "valid-key"})
+
+    assert response.status_code == 200
+    validator.assert_awaited_once_with("valid-key")
+
+
+@pytest.mark.asyncio
+async def test_actual_mcp_endpoint_accepts_bearer_and_x_api_key(monkeypatch):
+    validator = AsyncMock(side_effect=lambda key: f"user-for-{key}")
+    get_tools = AsyncMock(return_value=[])
+    execute_workflow = AsyncMock(
+        return_value={
+            "success": True,
+            "execution_id": "execution-1",
+            "project_id": "project-1",
+            "message": {"code": "0000", "data": {}},
+        }
+    )
+    monkeypatch.setattr(tools_config, "get_tools_for_user", get_tools)
+    monkeypatch.setattr(tools_config, "execute_workflow_by_name", execute_workflow)
+    test_session_manager = StreamableHTTPSessionManager(
+        app=mcp_server,
+        event_store=None,
+        json_response=False,
+        stateless=True,
+    )
+    test_auth_app = MCPAPIKeyAuthMiddleware(test_session_manager.handle_request, validator)
+    test_asgi_app = Starlette(routes=[Mount("/mcp", app=test_auth_app)])
+    httpx_client_factory = make_asgi_http_client_factory(test_asgi_app)
+
+    credential_cases = [
+        ({"Authorization": "Bearer bearer-key"}, "bearer-key"),
+        ({"X-API-Key": "header-key"}, "header-key"),
+    ]
+
+    async with test_session_manager.run():
+        for headers, expected_key in credential_cases:
+            async with streamablehttp_client(
+                "http://test/mcp/",
+                headers=headers,
+                terminate_on_close=False,
+                httpx_client_factory=httpx_client_factory,
+            ) as (read_stream, write_stream, _):
+                async with ClientSession(read_stream, write_stream) as client_session:
+                    await client_session.initialize()
+                    result = await client_session.list_tools()
+                    call_result = await client_session.call_tool("workflow-tool", {"value": 1})
+
+            assert result.tools == []
+            assert call_result.isError is False
+            assert validator.await_args.args == (expected_key,)
+
+    validated_keys = {call.args[0] for call in validator.await_args_list}
+    assert validated_keys == {"bearer-key", "header-key"}
+    listed_user_ids = {call.args[0] for call in get_tools.await_args_list}
+    assert listed_user_ids == {"user-for-bearer-key", "user-for-header-key"}
+    assert execute_workflow.await_count == 2
+    assert execute_workflow.await_args_list[0].args == (
+        "workflow-tool",
+        "user-for-bearer-key",
+        {"value": 1},
+    )
+    assert execute_workflow.await_args_list[1].args == (
+        "workflow-tool",
+        "user-for-header-key",
+        {"value": 1},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authorization",
+    ["valid-key", "Basic valid-key", "Bearer", "Bearer key extra"],
+)
+async def test_mcp_malformed_bearer_returns_401(authorization):
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(
+        auth_app,
+        headers={"Authorization": authorization},
+    )
+
+    assert response.status_code == 401
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mcp_invalid_or_revoked_key_returns_401():
+    validator = AsyncMock(return_value=None)
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(
+        auth_app,
+        headers={"Authorization": "Bearer revoked-key"},
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+    validator.assert_awaited_once_with("revoked-key")
+
+
+@pytest.mark.asyncio
+async def test_mcp_query_key_is_disabled_by_default():
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(auth_app, params={"key": "legacy-key"})
+
+    assert response.status_code == 401
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mcp_query_key_can_be_enabled_for_migration():
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(
+        empty_tools_app,
+        validator,
+        allow_query_api_key=True,
+    )
+
+    response = await request_mcp(auth_app, params={"key": "legacy-key"})
+
+    assert response.status_code == 200
+    validator.assert_awaited_once_with("legacy-key")
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_conflicting_credential_sources():
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(
+        auth_app,
+        headers={
+            "Authorization": "Bearer bearer-key",
+            "X-API-Key": "header-key",
+        },
+    )
+
+    assert response.status_code == 401
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [("Authorization", "Bearer first"), ("Authorization", "Bearer second")],
+        {"X-API-Key": ""},
+        [("X-API-Key", "first"), ("X-API-Key", "second")],
+    ],
+)
+async def test_mcp_rejects_duplicate_or_empty_headers(headers):
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(auth_app, headers=headers)
+
+    assert response.status_code == 401
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"key": ""},
+        [("key", "first"), ("key", "second")],
+    ],
+)
+async def test_mcp_rejects_empty_or_duplicate_query_keys(params):
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(
+        empty_tools_app,
+        validator,
+        allow_query_api_key=True,
+    )
+
+    response = await request_mcp(auth_app, params=params)
+
+    assert response.status_code == 401
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_header_and_enabled_query_key_together():
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(
+        empty_tools_app,
+        validator,
+        allow_query_api_key=True,
+    )
+
+    response = await request_mcp(
+        auth_app,
+        headers={"Authorization": "Bearer bearer-key"},
+        params={"key": "query-key"},
+    )
+
+    assert response.status_code == 401
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mcp_non_http_scope_passes_through():
+    downstream = AsyncMock()
+    validator = AsyncMock(return_value="user-1")
+    auth_app = MCPAPIKeyAuthMiddleware(downstream, validator)
+    receive = AsyncMock()
+    send = AsyncMock()
+    scope = {"type": "lifespan"}
+
+    await auth_app(scope, receive, send)
+
+    downstream.assert_awaited_once_with(scope, receive, send)
+    validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mcp_validator_failure_returns_503_without_exposing_error():
+    validator = AsyncMock(side_effect=RuntimeError("database connection failed"))
+    auth_app = MCPAPIKeyAuthMiddleware(empty_tools_app, validator)
+
+    response = await request_mcp(
+        auth_app,
+        headers={"Authorization": "Bearer secret-key"},
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Authentication service unavailable"}
+    assert "secret-key" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_api_key_lookup_accepts_active_and_rejects_revoked_key(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    OpenAPIDB.__table__.create(engine)
+    active_key = "active-test-api-key"
+    revoked_key = "revoked-test-api-key"
+
+    with Session(engine) as session:
+        session.add_all(
+            [
+                OpenAPIDB(
+                    user_id="user-active",
+                    api_key=APIKeyUtils.hash_api_key(active_key),
+                    prefix=active_key[:8],
+                    is_active=1,
+                ),
+                OpenAPIDB(
+                    user_id="user-revoked",
+                    api_key=APIKeyUtils.hash_api_key(revoked_key),
+                    prefix=revoked_key[:8],
+                    is_active=0,
+                ),
+            ]
+        )
+        session.commit()
+
+    monkeypatch.setattr(
+        database,
+        "AsyncSessionLocal",
+        lambda: AsyncSessionAdapter(Session(engine)),
+    )
+    config = ToolsConfig()
+
+    assert await config.get_uid_from_raw_key(active_key) == "user-active"
+    assert await config.get_uid_from_raw_key(revoked_key) is None
+
+    engine.dispose()

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -10,6 +10,9 @@ JFBYM_POINTS_COST=10
 AICHAT_BASE_URL=""
 AICHAT_API_KEY=""
 
+# Legacy MCP ?key= support. Keep disabled unless temporarily migrating clients.
+MCP_ALLOW_QUERY_API_KEY=false
+
 CUA_BASE_URL=""
 CUA_API_KEY=""
 

--- a/docker/volumes/nginx/default.conf
+++ b/docker/volumes/nginx/default.conf
@@ -104,10 +104,8 @@ server {
     # MCP 专用 location - 同时处理带/不带斜杠的请求
     location ~ ^/api/rpa-openapi/mcp/?$ {
         # MCP 接口跳过会话认证，使用 API Key 认证
-        # API Key 在查询参数中传递：?key=xxx
-        # 支持以下格式：
-        # - /api/rpa-openapi/mcp?key=xxx
-        # - /api/rpa-openapi/mcp/?key=xxx
+        # 首选 Authorization: Bearer 或 X-API-Key 请求头。
+        # 查询参数 ?key= 仅在 MCP_ALLOW_QUERY_API_KEY=true 时兼容。
         
         rewrite ^/api/rpa-openapi/mcp/?(.*)$ /mcp/$1 break;
         proxy_pass http://openapi-service;

--- a/engine/servers/astronverse-scheduler/pyproject.toml
+++ b/engine/servers/astronverse-scheduler/pyproject.toml
@@ -36,3 +36,8 @@ packages = ["src/astronverse"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+]

--- a/engine/servers/astronverse-scheduler/src/astronverse/scheduler/apis/connector/executor.py
+++ b/engine/servers/astronverse-scheduler/src/astronverse/scheduler/apis/connector/executor.py
@@ -179,10 +179,10 @@ def executor_run_list(task_info: TaskInfo, svc: Svc = Depends(get_svc)):
                     if task_info.exceptional == "jump":
                         break
                     elif task_info.exceptional == "retry_stop":
-                        if t == task_info.retry_num - 1:
+                        if t >= task_info.retry_num:
                             raise Exception("启动失败: {}".format(execute_reason))
                     elif task_info.exceptional == "retry_jump":
-                        if t == task_info.retry_num - 1:
+                        if t >= task_info.retry_num:
                             break
                     else:
                         # stop

--- a/engine/servers/astronverse-scheduler/tests/apis/connector/test_executor.py
+++ b/engine/servers/astronverse-scheduler/tests/apis/connector/test_executor.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from astronverse.scheduler.apis.connector import executor as executor_module
+from astronverse.scheduler.apis.connector.executor import RobotInfo, TaskInfo, executor_run_list
+from astronverse.scheduler.core.executor.executor import ExecuteStatus, TaskExecuteStatus
+
+
+def make_executor(status: ExecuteStatus, reason: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        execute_status=status,
+        execute_reason=reason,
+        execute_data={},
+    )
+
+
+def make_svc(create_side_effect) -> SimpleNamespace:
+    executor_mg = MagicMock()
+    executor_mg.status.return_value = False
+    executor_mg.create.side_effect = create_side_effect
+
+    return SimpleNamespace(
+        executor_mg=executor_mg,
+        terminal_mod=False,
+        terminal_task_stop=False,
+        rpa_route_port=0,
+    )
+
+
+def make_task(exceptional: str, retry_num: int) -> TaskInfo:
+    return TaskInfo(
+        trigger_id="task-1",
+        trigger_name="retry regression",
+        task_type="schedule",
+        exceptional=exceptional,
+        retry_num=retry_num,
+        callback_project_ids=[
+            RobotInfo(robotId="robot-1", robotName="failing robot", sort=1),
+            RobotInfo(robotId="robot-2", robotName="successful robot", sort=2),
+        ],
+    )
+
+
+@pytest.fixture
+def reported_statuses(monkeypatch) -> list[TaskExecuteStatus]:
+    statuses = []
+
+    def fake_report_task_log(
+        svc,
+        status: TaskExecuteStatus,
+        task_id=None,
+        task_execute_id=None,
+    ):
+        statuses.append(status)
+        if status == TaskExecuteStatus.EXECUTING:
+            return "task-execution-1"
+        return None
+
+    monkeypatch.setattr(executor_module, "report_task_log", fake_report_task_log)
+    monkeypatch.setattr(executor_module, "get_settings", lambda: {})
+    monkeypatch.setattr(executor_module, "emit_to_front", MagicMock())
+
+    return statuses
+
+
+@pytest.mark.parametrize(
+    ("retry_num", "expected_attempts"),
+    [(0, 1), (1, 2), (2, 3)],
+)
+def test_retry_stop_stops_after_configured_retries(
+    retry_num: int,
+    expected_attempts: int,
+    reported_statuses: list[TaskExecuteStatus],
+) -> None:
+    svc = make_svc(
+        lambda **kwargs: make_executor(
+            ExecuteStatus.FAIL,
+            reason="recoverable failure",
+        )
+    )
+
+    result = executor_run_list(make_task("retry_stop", retry_num), svc)
+    created_projects = [
+        call.kwargs["project_id"] for call in svc.executor_mg.create.call_args_list
+    ]
+
+    assert created_projects == ["robot-1"] * expected_attempts
+    assert reported_statuses == [
+        TaskExecuteStatus.EXECUTING,
+        TaskExecuteStatus.EXEC_ERROR,
+    ]
+    assert "recoverable failure" in result["msg"]
+
+
+@pytest.mark.parametrize(
+    ("retry_num", "expected_attempts"),
+    [(0, 1), (1, 2), (2, 3)],
+)
+def test_retry_jump_continues_after_configured_retries(
+    retry_num: int,
+    expected_attempts: int,
+    reported_statuses: list[TaskExecuteStatus],
+) -> None:
+    def create_executor(**kwargs):
+        if kwargs["project_id"] == "robot-1":
+            return make_executor(
+                ExecuteStatus.FAIL,
+                reason="recoverable failure",
+            )
+        return make_executor(ExecuteStatus.SUCCESS)
+
+    svc = make_svc(create_executor)
+
+    result = executor_run_list(make_task("retry_jump", retry_num), svc)
+    created_projects = [
+        call.kwargs["project_id"] for call in svc.executor_mg.create.call_args_list
+    ]
+
+    assert created_projects == ["robot-1"] * expected_attempts + ["robot-2"]
+    assert reported_statuses == [
+        TaskExecuteStatus.EXECUTING,
+        TaskExecuteStatus.SUCCESS,
+    ]
+    assert result["code"] == "0000"
+    assert result["data"] == {}

--- a/engine/servers/astronverse-scheduler/uv.lock
+++ b/engine/servers/astronverse-scheduler/uv.lock
@@ -78,6 +78,12 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchdog" },
     { name = "websocket-client" },
+    { name = "websockify" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -99,7 +105,11 @@ requires-dist = [
     { name = "uvicorn" },
     { name = "watchdog" },
     { name = "websocket-client" },
+    { name = "websockify" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.1" }]
 
 [[package]]
 name = "astronverse-websocket-server"
@@ -151,6 +161,8 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
     { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
     { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
@@ -158,18 +170,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
     { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
     { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
     { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
     { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
     { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
     { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
     { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
     { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
     { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
     { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
     { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -233,6 +258,7 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/19/f748958276519adf6a0c1e79e7b8860b4830dda55ccdf29f2719b5fc499c/cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59", size = 749301, upload-time = "2026-01-28T00:24:37.379Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/99/157aae7949a5f30d51fcb1a9851e8ebd5c74bf99b5285d8bb4b8b9ee641e/cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485", size = 7173686, upload-time = "2026-01-28T00:23:07.515Z" },
     { url = "https://files.pythonhosted.org/packages/87/91/874b8910903159043b5c6a123b7e79c4559ddd1896e38967567942635778/cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc", size = 4275871, upload-time = "2026-01-28T00:23:09.439Z" },
     { url = "https://files.pythonhosted.org/packages/c0/35/690e809be77896111f5b195ede56e4b4ed0435b428c2f2b6d35046fbb5e8/cryptography-46.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0", size = 4423124, upload-time = "2026-01-28T00:23:11.529Z" },
     { url = "https://files.pythonhosted.org/packages/1a/5b/a26407d4f79d61ca4bebaa9213feafdd8806dc69d3d290ce24996d3cfe43/cryptography-46.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa", size = 4277090, upload-time = "2026-01-28T00:23:13.123Z" },
@@ -244,6 +270,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/f7/6d43cbaddf6f65b24816e4af187d211f0bc536a29961f69faedc48501d8e/cryptography-46.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616", size = 4454641, upload-time = "2026-01-28T00:23:22.866Z" },
     { url = "https://files.pythonhosted.org/packages/9e/4f/ebd0473ad656a0ac912a16bd07db0f5d85184924e14fc88feecae2492834/cryptography-46.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0", size = 4405159, upload-time = "2026-01-28T00:23:25.278Z" },
     { url = "https://files.pythonhosted.org/packages/d1/f7/7923886f32dc47e27adeff8246e976d77258fd2aa3efdd1754e4e323bf49/cryptography-46.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0", size = 4666059, upload-time = "2026-01-28T00:23:26.766Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a7/0fca0fd3591dffc297278a61813d7f661a14243dd60f499a7a5b48acb52a/cryptography-46.0.4-cp311-abi3-win32.whl", hash = "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5", size = 3026378, upload-time = "2026-01-28T00:23:28.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/12/652c84b6f9873f0909374864a57b003686c642ea48c84d6c7e2c515e6da5/cryptography-46.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b", size = 3478614, upload-time = "2026-01-28T00:23:30.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/27/542b029f293a5cce59349d799d4d8484b3b1654a7b9a0585c266e974a488/cryptography-46.0.4-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:485e2b65d25ec0d901bca7bcae0f53b00133bf3173916d8e421f6fddde103908", size = 7116417, upload-time = "2026-01-28T00:23:31.958Z" },
     { url = "https://files.pythonhosted.org/packages/f8/f5/559c25b77f40b6bf828eabaf988efb8b0e17b573545edb503368ca0a2a03/cryptography-46.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:078e5f06bd2fa5aea5a324f2a09f914b1484f1d0c2a4d6a8a28c74e72f65f2da", size = 4264508, upload-time = "2026-01-28T00:23:34.264Z" },
     { url = "https://files.pythonhosted.org/packages/49/a1/551fa162d33074b660dc35c9bc3616fefa21a0e8c1edd27b92559902e408/cryptography-46.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dce1e4f068f03008da7fa51cc7abc6ddc5e5de3e3d1550334eaf8393982a5829", size = 4409080, upload-time = "2026-01-28T00:23:35.793Z" },
     { url = "https://files.pythonhosted.org/packages/b0/6a/4d8d129a755f5d6df1bbee69ea2f35ebfa954fa1847690d1db2e8bca46a5/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2067461c80271f422ee7bdbe79b9b4be54a5162e90345f86a23445a0cf3fd8a2", size = 4270039, upload-time = "2026-01-28T00:23:37.263Z" },
@@ -255,6 +284,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/83/17/259409b8349aa10535358807a472c6a695cf84f106022268d31cea2b6c97/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:df4a817fa7138dd0c96c8c8c20f04b8aaa1fac3bbf610913dcad8ea82e1bfd3f", size = 4441254, upload-time = "2026-01-28T00:23:48.403Z" },
     { url = "https://files.pythonhosted.org/packages/9c/fe/e4a1b0c989b00cee5ffa0764401767e2d1cf59f45530963b894129fd5dce/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b1de0ebf7587f28f9190b9cb526e901bf448c9e6a99655d2b07fff60e8212a82", size = 4396520, upload-time = "2026-01-28T00:23:50.26Z" },
     { url = "https://files.pythonhosted.org/packages/b3/81/ba8fd9657d27076eb40d6a2f941b23429a3c3d2f56f5a921d6b936a27bc9/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9b4d17bc7bd7cdd98e3af40b441feaea4c68225e2eb2341026c84511ad246c0c", size = 4651479, upload-time = "2026-01-28T00:23:51.674Z" },
+    { url = "https://files.pythonhosted.org/packages/00/03/0de4ed43c71c31e4fe954edd50b9d28d658fef56555eba7641696370a8e2/cryptography-46.0.4-cp314-cp314t-win32.whl", hash = "sha256:c411f16275b0dea722d76544a61d6421e2cc829ad76eec79280dbdc9ddf50061", size = 3001986, upload-time = "2026-01-28T00:23:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/70/81830b59df7682917d7a10f833c4dab2a5574cd664e86d18139f2b421329/cryptography-46.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:728fedc529efc1439eb6107b677f7f7558adab4553ef8669f0d02d42d7b959a7", size = 3468288, upload-time = "2026-01-28T00:23:55.09Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f7/f648fdbb61d0d45902d3f374217451385edc7e7768d1b03ff1d0e5ffc17b/cryptography-46.0.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab", size = 7169583, upload-time = "2026-01-28T00:23:56.558Z" },
     { url = "https://files.pythonhosted.org/packages/d8/cc/8f3224cbb2a928de7298d6ed4790f5ebc48114e02bdc9559196bfb12435d/cryptography-46.0.4-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef", size = 4275419, upload-time = "2026-01-28T00:23:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/17/43/4a18faa7a872d00e4264855134ba82d23546c850a70ff209e04ee200e76f/cryptography-46.0.4-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d", size = 4419058, upload-time = "2026-01-28T00:23:59.867Z" },
     { url = "https://files.pythonhosted.org/packages/ee/64/6651969409821d791ba12346a124f55e1b76f66a819254ae840a965d4b9c/cryptography-46.0.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973", size = 4278151, upload-time = "2026-01-28T00:24:01.731Z" },
@@ -266,6 +298,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/03/c3/c90a2cb358de4ac9309b26acf49b2a100957e1ff5cc1e98e6c4996576710/cryptography-46.0.4-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019", size = 4451216, upload-time = "2026-01-28T00:24:13.975Z" },
     { url = "https://files.pythonhosted.org/packages/96/2c/8d7f4171388a10208671e181ca43cdc0e596d8259ebacbbcfbd16de593da/cryptography-46.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4", size = 4404299, upload-time = "2026-01-28T00:24:16.169Z" },
     { url = "https://files.pythonhosted.org/packages/e9/23/cbb2036e450980f65c6e0a173b73a56ff3bccd8998965dea5cc9ddd424a5/cryptography-46.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b", size = 4664837, upload-time = "2026-01-28T00:24:17.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/21/f7433d18fe6d5845329cbdc597e30caf983229c7a245bcf54afecc555938/cryptography-46.0.4-cp38-abi3-win32.whl", hash = "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc", size = 3009779, upload-time = "2026-01-28T00:24:20.198Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/6a/bd2e7caa2facffedf172a45c1a02e551e6d7d4828658c9a245516a598d94/cryptography-46.0.4-cp38-abi3-win_amd64.whl", hash = "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976", size = 3466633, upload-time = "2026-01-28T00:24:21.851Z" },
 ]
 
 [[package]]
@@ -335,6 +369,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -386,6 +429,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jwcrypto"
+version = "1.5.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/7e/53c14813521693e931e420d9db00efe317419ff194495903bce03402275e/jwcrypto-1.5.8.tar.gz", hash = "sha256:c3d7114b6f6e65b52f6b7da817eb8cb8423e1da31e1ef13508447c81ecbdcc34", size = 90772, upload-time = "2026-06-24T19:36:50.782Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/7c/f87c5db042c4f7b4476346fc0d22f1025a777fee08eebde3720d3b9c4eb5/jwcrypto-1.5.8-py3-none-any.whl", hash = "sha256:85aeb475f808d56bbc2f2ed1f6f73e6a317c4011a4321505f02f0aed695a3742", size = 96133, upload-time = "2026-06-24T19:36:49.519Z" },
 ]
 
 [[package]]
@@ -454,6 +510,68 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c6/28de0191c5f82b7d42a0a51390ba98587048aa93a39fafb05bdbe6e8d00c/numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f", size = 16885274, upload-time = "2026-08-09T13:47:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/973ca116000d244897e468ea1aff30b589e5022e3c8744b71706fe33bd57/numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842", size = 11907846, upload-time = "2026-08-09T13:47:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d9/8c4b3937ef204cb2fd88d389ccd0f265a2ffb11f35a01d2064cf46714bd6/numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6", size = 5354892, upload-time = "2026-08-09T13:47:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/b6ee65ea2999fdb7023935e108e6fb776ee4082aa15f159acfa857e578c8/numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8", size = 6679309, upload-time = "2026-08-09T13:47:20.456Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f3/acb18d8b137a393c8e7803a8c994c9e64bde3930692a69d826993113a159/numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69", size = 15625850, upload-time = "2026-08-09T13:47:24.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bf/a8e9bb0db815a0e265b5744ebedd3af0bd5faad8604e5b50a1cd012f3c91/numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab", size = 16713664, upload-time = "2026-08-09T13:47:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/6e913736b3dd6582344af32418b5fb9dab34282e8a8174ae1d54ceb0fc13/numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514", size = 16986749, upload-time = "2026-08-09T13:47:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/7d3b23eff5c7428ef6c01e6f7052bb60d504c4d33e317b36b8959c24ad97/numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710", size = 18470495, upload-time = "2026-08-09T13:47:35.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a4/68a321d825374f6eb677ffe8ef8c6b9a328304e6fd2e39d9530822776607/numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617", size = 6120696, upload-time = "2026-08-09T13:47:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/deafbb1700f79fae9cd1e91220f133d124cc267de1b584da3fbf6db2f6cd/numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7", size = 12597324, upload-time = "2026-08-09T13:47:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cd/3272ba105e3bbbdaeb11357eda31e7a6825ffe159e8171665660299a948f/numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788", size = 10680466, upload-time = "2026-08-09T13:47:44.873Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/58370637b1bb70a5c9ce2b43f4b521ccb224e36ccb76a6596b17ae4b447c/numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b", size = 16993947, upload-time = "2026-08-09T13:47:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/93/2abcb807712b289d6d60fe4cf30532f98974a8396d885650f3ba5a13026e/numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e", size = 12025331, upload-time = "2026-08-09T13:47:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3a/2898e003a5fbaf87e76c039b4ee1f5eb390471b4ffe74887c1f34c4e791e/numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a", size = 5472336, upload-time = "2026-08-09T13:47:55.403Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/23f69d07c544597b29758b31b55c27dc9d541012a2c1496189fef702aec2/numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8", size = 6788387, upload-time = "2026-08-09T13:47:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ea/c0dbdbcf22f43782510a3e492dd3da73c6112b69cac8929d16d127536fc4/numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc", size = 15667096, upload-time = "2026-08-09T13:48:01.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/29c73c31748cdb0f7566642125ba17fd5b56780cddf891b085dab27e4466/numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec", size = 16751730, upload-time = "2026-08-09T13:48:05.706Z" },
+    { url = "https://files.pythonhosted.org/packages/47/95/02501e8454796bb58dadf7a99d3181e0b464bf264e1003039572f9779fac/numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0", size = 17038686, upload-time = "2026-08-09T13:48:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/53a681d91b5c82687067d8ea5035e02d917b5509d6f334cb06484a954714/numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2", size = 18507727, upload-time = "2026-08-09T13:48:13.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
 ]
 
 [[package]]
@@ -616,6 +734,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/70/c7a4f46dbf06048c6d57d9489b8e0f9c4c3d36b7479f03c5ca97eaa2541d/PyGetWindow-0.0.9.tar.gz", hash = "sha256:17894355e7d2b305cd832d717708384017c1698a90ce24f6f7fbf0242dd0a688", size = 9699, upload-time = "2020-10-04T02:12:50.806Z" }
 
 [[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
 name = "pymsgbox"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -717,6 +844,22 @@ name = "pyscreeze"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/f0/cb456ac4f1a73723d5b866933b7986f02bacea27516629c00f8e7da94c2d/pyscreeze-1.0.1.tar.gz", hash = "sha256:cf1662710f1b46aa5ff229ee23f367da9e20af4a78e6e365bee973cad0ead4be", size = 27826, upload-time = "2024-08-20T23:03:07.291Z" }
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
 
 [[package]]
 name = "python-lsp-jsonrpc"
@@ -832,6 +975,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]
@@ -1032,6 +1184,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
+]
+
+[[package]]
+name = "websockify"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jwcrypto" },
+    { name = "numpy" },
+    { name = "redis" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/9e/fa7b6322fe22a02cf34256cbe300a9468533038b1262c7960119a787b595/websockify-0.13.0.tar.gz", hash = "sha256:9969731116653226c4c499a8a50712c8f3f7c105c615ead7ebc6ae781f0ba954", size = 50653, upload-time = "2025-05-26T14:40:14.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/e8/6476cd85a71f7cfb04ca1e199809b75bc8580d075d4338ffcde4c761d620/websockify-0.13.0-py3-none-any.whl", hash = "sha256:ac497a8dafc7f51d28ca989f01cdf5f8add663a497d425a56b159dcb8d6a314c", size = 41537, upload-time = "2025-05-26T14:40:12.915Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This closes #854.

## 目的和内容

修复 MCP 鉴权失败语义不明确、标准 Header 凭据不受支持，以及执行记录缺少用户隔离的问题。统一 MCP 鉴权身份、工作流权限检查、执行记录和客户端派发所使用的用户身份，确保执行记录所属用户与实际执行用户一致。

## 🎯 变更类型 | Change Type
- 🐛 Bug 修复 | Bug Fix

## 变更内容

### MCP 鉴权
- 支持 `Authorization: Bearer <API_KEY>`。
- 支持 `X-API-Key: <API_KEY>`。
- URL `?key=` 默认关闭，可通过 `MCP_ALLOW_QUERY_API_KEY=true` 临时启用。
- 拒绝缺失、空值、重复、格式错误或来源冲突的凭据。
- 无效或已吊销的 API Key 返回 HTTP `401`。
- 鉴权依赖异常返回 HTTP `503`，不再返回 `tool list 0` 这种伪装为正常的空工具列表。
- 鉴权成功后，将可信 `user_id` 写入 MCP Request State，由 `tools/list` 和 `tools/call` 统一读取。

### 身份一致性与用户隔离
- 工作流权限检查和执行创建使用同一个 MCP 鉴权用户。
- 创建执行记录时，将鉴权用户写入 `Execution.user_id`。
- 执行详情使用 `execution_id + user_id` 联合查询。
- 跨用户访问与记录不存在统一返回 `404`，避免泄露资源是否存在。
- 执行取消操作校验执行记录所属用户。
- 后台状态更新使用内部查询方法，不受外部用户隔离接口影响。

### 单一可信执行身份
- 移除后台执行链中重复传递的独立 `user_id` 参数。
- 后台任务根据 `execution_id` 重新读取已提交的执行记录。
- WebSocket `send_uuid` 只使用 `Execution.user_id`。
- 执行记录缺少用户身份时拒绝派发。
- 创建和派发日志使用同一组 `execution_id + Execution.user_id`，避免审计身份分叉。
- 未修改工作流参数、执行协议、结果处理和客户端业务逻辑。

### 配置和文档(markdown)
- 增加 `MCP_ALLOW_QUERY_API_KEY` 配置说明。
- 更新 OpenAPI YAML、环境变量示例及中英文 README。
- 补充 Bearer、`X-API-Key` 和 URL Key 迁移方式说明。

## 测试

### 测试覆盖
- Bearer 和 `X-API-Key` 鉴权。
- 缺失、无效、吊销、空值、重复和冲突凭据。
- URL Key 默认关闭及迁移期开启。
- 真实 MCP `initialize → tools/list → tools/call` 调用链。
- MCP 鉴权身份传递到工作流执行入口。
- 鉴权身份写入 `Execution.user_id`。
- 后台执行不接受第二个用户身份。
- WebSocket 派发只使用执行记录中的用户。
- 执行记录缺少身份时拒绝派发。
- 双用户执行详情读取和取消隔离。
- 跨用户访问与不存在记录返回相同结果。
- 已吊销 API Key 的数据库校验。

### 结果
- 相关 UT：`32 passed`
- MCP 鉴权模块覆盖率：`100%`
- OpenAPI Service 测试收集：`56 tests collected`
- Ruff 检查：通过
- Ruff Format：通过
- Python 语法检查：通过
- `git diff --check`：通过

完整集成测试依赖本机 MySQL `3307` 和 Redis `6380`。本地环境未启动这两个服务，因此未宣称全部 56 项集成测试均已执行通过。