### PR TITLE
fix:对敏感信息可能进入 OpenAPI、rpa-auth 和 nginx 日志的问题进行修复

### DIFF
--- a/backend/openapi-service/app/logger.py
+++ b/backend/openapi-service/app/logger.py
@@ -4,8 +4,15 @@ from logging.handlers import RotatingFileHandler
 
 from app.config import get_settings
 from app.middlewares.tracing import RequestIdFilter
+from app.utils.sensitive_logging import SensitiveDataFilter, SensitiveFormatter
 
 LOG_LEVEL = get_settings().LOG_LEVEL
+SENSITIVE_DATA_FILTER = SensitiveDataFilter()
+
+
+def _add_sensitive_filter(filter_target):
+    if not any(isinstance(item, SensitiveDataFilter) for item in filter_target.filters):
+        filter_target.addFilter(SENSITIVE_DATA_FILTER)
 
 
 def get_logger(name=None, log_level=LOG_LEVEL):
@@ -16,7 +23,7 @@ def get_logger(name=None, log_level=LOG_LEVEL):
 
     logger.setLevel(log_level)
 
-    default_formatter = logging.Formatter(
+    default_formatter = SensitiveFormatter(
         "%(asctime)s - %(name)s - [%(request_id)s] - %(levelname)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
@@ -29,12 +36,13 @@ def get_logger(name=None, log_level=LOG_LEVEL):
     #     else default_formatter
     # )
 
-    filter = RequestIdFilter()
+    request_id_filter = RequestIdFilter()
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(default_formatter)
 
-    console_handler.addFilter(filter)
+    console_handler.addFilter(request_id_filter)
+    _add_sensitive_filter(console_handler)
 
     logger.addHandler(console_handler)
 
@@ -46,7 +54,16 @@ def get_logger(name=None, log_level=LOG_LEVEL):
         backupCount=10,
     )
     file_handler.setFormatter(default_formatter)
-    file_handler.addFilter(filter)
+    file_handler.addFilter(request_id_filter)
+    _add_sensitive_filter(file_handler)
     logger.addHandler(file_handler)
+
+    # Uvicorn owns its access handlers. Attach the same redactor so a legacy
+    # MCP ?key= query cannot be written by the application server access log.
+    for external_logger_name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        external_logger = logging.getLogger(external_logger_name)
+        _add_sensitive_filter(external_logger)
+        for handler in external_logger.handlers:
+            _add_sensitive_filter(handler)
 
     return logger

--- a/backend/openapi-service/app/routers/workflows.py
+++ b/backend/openapi-service/app/routers/workflows.py
@@ -240,7 +240,7 @@ async def execute_workflow_async(
                 )
                 if response.status_code == 200:
                     result = response.json().get("data")
-                    logger.info(f"复制工作流结果: {result}")
+                    logger.info("Workflow copy completed with status %s", response.status_code)
                     if not result:
                         return StandardResponse(
                             code=ResCode.ERR,
@@ -248,7 +248,7 @@ async def execute_workflow_async(
                             data=None,
                         )
                 else:
-                    logger.error(f"Failed to copy workflow: HTTP {response.status_code}, {response.text}")
+                    logger.error("Failed to copy workflow: HTTP %s", response.status_code)
                     return StandardResponse(code=ResCode.ERR, msg="请求后端拷贝工作流接口失败", data=None)
 
             workflow_data = WorkflowBase(
@@ -343,7 +343,7 @@ async def stop_current_workflow(user_id: str = Depends(get_user_id_from_api_key)
             nonlocal wait, res, res_e
             if watch_msg:
                 res = watch_msg.data
-                logger.info("Received response for stop_current: %s", res)
+                logger.info("Received response for stop_current")
             if e:
                 res_e = e
                 logger.error("Received error for stop_current: %s", e)
@@ -433,7 +433,7 @@ async def copy_workflow(
                 result = response.json()
                 return StandardResponse(code=ResCode.SUCCESS, msg="工作流复制成功", data=result)
             else:
-                logger.error(f"Failed to copy workflow: HTTP {response.status_code}, {response.text}")
+                logger.error("Failed to copy workflow: HTTP %s", response.status_code)
                 return StandardResponse(code=ResCode.ERR, msg=f"复制失败: HTTP {response.status_code}", data=None)
 
     except httpx.RequestError as e:

--- a/backend/openapi-service/app/services/api_key.py
+++ b/backend/openapi-service/app/services/api_key.py
@@ -32,7 +32,6 @@ class ApiKeyService:
 
         # 生成唯一ID和密钥
         api_key = APIKeyUtils.generate_api_key()
-        logger.info("Generated API key: %s", api_key)
         hashed_key = APIKeyUtils.hash_api_key(api_key)
         prefix = api_key[:8]
         name = api_key_data.name
@@ -53,6 +52,8 @@ class ApiKeyService:
 
         # 清除缓存
         await self._invalidate_api_keys_cache(user_id)
+
+        logger.info("Generated API key for user %s", user_id)
 
         return api_key
 

--- a/backend/openapi-service/app/services/execution.py
+++ b/backend/openapi-service/app/services/execution.py
@@ -228,7 +228,7 @@ class ExecutionService:
                         await update_service.update_execution_status(
                             execution_id, ExecutionStatus.FAILED.value, error=str(e)
                         )
-                except Exception as update_error:
+                except Exception:
                     logger.exception("Failed to update execution status for %s", execution_id)
 
     async def _execute_workflow_logic(self, execution: Execution, user_id: str) -> None:
@@ -259,7 +259,7 @@ class ExecutionService:
                 nonlocal wait, res, res_e
                 if watch_msg:
                     res = watch_msg.data
-                    logger.info("Received response for execution %s: %s", execution.id, res)
+                    logger.info("Received response for execution %s", execution.id)
                     # Received response for execution 71e3147f-55cd-43f5-b7a8-b734d1075618:
                     # {'code': '5001', 'msg': '', 'data': None}
                 if e:
@@ -273,7 +273,7 @@ class ExecutionService:
             elif isinstance(execution.parameters, str):
                 try:
                     parameters_dict = json.loads(execution.parameters)
-                except json.JSONDecodeError as e:
+                except json.JSONDecodeError:
                     logger.exception("Failed to parse parameters JSON for execution %s", execution.id)
                     parameters_dict = {}
             else:
@@ -281,7 +281,7 @@ class ExecutionService:
 
             run_param = []
             for key, value in parameters_dict.items():
-                logger.debug("参数: %s=%s", key, value)
+                logger.debug("Preparing workflow parameter: %s", key)
                 run_param.append({"varName": key, "varValue": value})
             run_param = json.dumps(run_param, ensure_ascii=False)
 
@@ -305,7 +305,7 @@ class ExecutionService:
                 data=executor_data,
             ).init()
 
-            logger.info("Sending WebSocket message for execution %s: %s", execution.id, base_msg.data)
+            logger.info("Sending WebSocket message for execution %s", execution.id)
             await websocket_service.ws_manager.send_reply(base_msg, 10 * 3600, callback)
 
             # 等待
@@ -331,7 +331,7 @@ class ExecutionService:
                 )
                 logger.info("Updated execution %s status to FAILED", execution.id)
 
-        except Exception as e:
+        except Exception:
             logger.exception("Error in workflow execution logic for %s", execution.id)
             raise
 
@@ -349,6 +349,6 @@ class ExecutionService:
             updated_execution = await self.update_execution_status(execution_id, ExecutionStatus.CANCELLED.value)
 
             return updated_execution is not None
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to cancel execution %s", execution_id)
             return False

--- a/backend/openapi-service/app/services/user.py
+++ b/backend/openapi-service/app/services/user.py
@@ -54,20 +54,15 @@ class UserService:
                 # 检查 HTTP 状态码
                 if response.status_code != 200:
                     logger.error(
-                        "外部接口返回异常状态码，phone: %s, status_code: %s, response: %s",
+                        "外部接口返回异常状态码，phone: %s, status_code: %s",
                         phone,
                         response.status_code,
-                        response.text,
                     )
                     return None
 
                 # 解析返回数据
                 response_data = response.json()
-                logger.info(
-                    "外部接口返回数据，phone: %s, response: %s",
-                    phone,
-                    json.dumps(response_data, ensure_ascii=False),
-                )
+                logger.info("外部接口调用成功，phone: %s, code: %s", phone, response_data.get("code"))
 
                 # 提取完整的用户信息
                 user_data = response_data.get("data", {})
@@ -79,16 +74,16 @@ class UserService:
                 logger.info("外部接口返回成功，phone: %s, user_id: %s", phone, user_id)
                 return user_data
 
-        except httpx.TimeoutException as e:
+        except httpx.TimeoutException:
             logger.exception("调用外部接口超时，phone: %s", phone)
             return None
-        except httpx.RequestError as e:
+        except httpx.RequestError:
             logger.exception("调用外部接口请求错误，phone: %s", phone)
             return None
-        except json.JSONDecodeError as e:
+        except json.JSONDecodeError:
             logger.exception("解析外部接口返回数据失败，phone: %s", phone)
             return None
-        except Exception as e:
+        except Exception:
             logger.exception("调用外部接口发生异常，phone: %s", phone)
             return None
 
@@ -122,22 +117,17 @@ class UserService:
                 # 检查 HTTP 状态码
                 if response.status_code != 200:
                     logger.error(
-                        "外部接口返回异常状态码，phone: %s, status_code: %s, response: %s",
+                        "外部接口返回异常状态码，phone: %s, status_code: %s",
                         phone,
                         response.status_code,
-                        response.text,
                     )
                     return None
 
                 # 解析返回数据
                 response_data = response.json()
-                logger.info(
-                    "外部接口返回数据，phone: %s, response: %s",
-                    phone,
-                    json.dumps(response_data, ensure_ascii=False),
-                )
+                logger.info("外部接口调用成功，phone: %s, code: %s", phone, response_data.get("code"))
                 if response_data.get("code") == "500000":
-                    logger.error("查询用户信息报错，%s", response_data.get("message"))
+                    logger.error("查询用户信息接口返回业务错误，code: %s", response_data.get("code"))
                     return None
 
                 # 提取完整的用户信息
@@ -150,16 +140,16 @@ class UserService:
                 logger.info("外部接口返回成功，phone: %s, user_id: %s", phone, user_id)
                 return user_data
 
-        except httpx.TimeoutException as e:
+        except httpx.TimeoutException:
             logger.exception("调用外部接口超时，phone: %s", phone)
             return None
-        except httpx.RequestError as e:
+        except httpx.RequestError:
             logger.exception("调用外部接口请求错误，phone: %s", phone)
             return None
-        except json.JSONDecodeError as e:
+        except json.JSONDecodeError:
             logger.exception("解析外部接口返回数据失败，phone: %s", phone)
             return None
-        except Exception as e:
+        except Exception:
             logger.exception("调用外部接口发生异常，phone: %s", phone)
             return None
 
@@ -207,7 +197,7 @@ class UserService:
                 api_key_data = ApiKeyCreate(name=f"default_key_{phone}")
                 default_api_key = await self.api_key_service.create_api_key(api_key_data, user_id)
                 logger.info("为用户生成默认API Key，user_id: %s", user_id)
-            except Exception as e:
+            except Exception:
                 logger.exception("生成API Key失败，user_id: %s", user_id)
                 # API Key生成失败不影响用户创建
 
@@ -274,7 +264,7 @@ class UserService:
                 api_key_data = ApiKeyCreate(name=f"default_key_{phone}")
                 default_api_key = await self.api_key_service.create_api_key(api_key_data, user_id)
                 logger.info("为用户生成默认API Key，user_id: %s", user_id)
-            except Exception as e:
+            except Exception:
                 logger.exception("生成API Key失败，user_id: %s", user_id)
                 # API Key生成失败不影响用户创建
 

--- a/backend/openapi-service/app/services/websocket.py
+++ b/backend/openapi-service/app/services/websocket.py
@@ -26,7 +26,19 @@ class WsService(IWebSocket):
 
 
 def ws_log(msg):
-    logger.info(msg)
+    message = str(msg)
+    if message.startswith(">>>"):
+        logger.debug("WebSocket message sent")
+    elif message.startswith("<<<"):
+        logger.debug("WebSocket message received")
+    elif message.startswith("_add_conn "):
+        logger.info("WebSocket connection added")
+    elif message.startswith("_del_conn "):
+        logger.info("WebSocket connection removed")
+    elif message.startswith(("error", "listen error", "uuid empty")):
+        logger.warning("WebSocket manager reported an error")
+    else:
+        logger.debug("WebSocket manager event")
 
 
 class WsManagerService:

--- a/backend/openapi-service/app/services/workflow.py
+++ b/backend/openapi-service/app/services/workflow.py
@@ -203,7 +203,6 @@ class WorkflowService:
             return workflow
 
         if "parameters" in workflow_dict:
-            logger.info(workflow_dict["parameters"])
             # 用户没设置parameters，去请求接口并比较
             merged_params = await self._compare_and_merge_parameters(
                 workflow_dict["parameters"],  # 新参数为None表示用户未设置

--- a/backend/openapi-service/app/utils/api_key.py
+++ b/backend/openapi-service/app/utils/api_key.py
@@ -3,10 +3,6 @@ import string
 
 import bcrypt
 
-from app.logger import get_logger
-
-logger = get_logger(__name__)
-
 
 class APIKeyUtils:
     @staticmethod
@@ -24,5 +20,4 @@ class APIKeyUtils:
 
     @staticmethod
     def verify_api_key(input_key, hashed_key):
-        logger.info(f"input_key: {input_key}, hashed_key: {hashed_key}")
         return bcrypt.checkpw(input_key.encode("utf-8"), hashed_key.encode("utf-8"))

--- a/backend/openapi-service/app/utils/sensitive_logging.py
+++ b/backend/openapi-service/app/utils/sensitive_logging.py
@@ -1,0 +1,77 @@
+import logging
+import re
+
+REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEY = (
+    r"(?:api[ _-]?key|api[ _-]?secret|hashed[ _-]?key|password|passwd|pwd|"
+    r"confirm[ _-]?password|old[ _-]?password|new[ _-]?password|"
+    r"access[ _-]?token|refresh[ _-]?token|id[ _-]?token|temp[ _-]?token|token|"
+    r"authorization|cookie|cache[ _-]?key|session(?:[ _-]?id)?|jsessionid|casdoor[ _-]?session[ _-]?id|"
+    r"verification[ _-]?code|verify[ _-]?code|sms[ _-]?code|captcha|credential)"
+)
+
+_QUOTED_VALUE = re.compile(rf"(?i)([\"']{_SENSITIVE_KEY}[\"']\s*[:=]\s*[\"'])(.*?)([\"'])")
+_QUOTED_ARRAY_VALUE = re.compile(rf"(?i)([\"']{_SENSITIVE_KEY}[\"']\s*[:=]\s*\[)[^\]]*(\])")
+_LABEL_VALUE = re.compile(rf"(?i)(\b{_SENSITIVE_KEY}\b\s*[:=：]\s*)(?!{re.escape(REDACTED)})([^\s,;&}}\]]+)")
+_CHINESE_SECRET_VALUE = re.compile(
+    rf"((?:临时凭证|验证码|密码|口令|访问令牌|刷新令牌|会话(?:\s*ID)?|密钥)"
+    rf"\s*[:=：]\s*)(?!{re.escape(REDACTED)})([^\s,，；}}\]]+)"
+)
+_BEARER_VALUE = re.compile(r"(?i)(\bBearer\s+)([^\s,;]+)")
+_QUERY_API_KEY = re.compile(r"(?i)([?&]key=)([^&\s]+)")
+_COOKIE_HEADER = re.compile(r"(?i)(\bCookie(?:\s+header)?\s*[:=]\s*)([^\r\n]+)")
+_PHONE_VALUE = re.compile(r"(?i)((?:phone|mobile|手机号)\s*[\"']?\s*[:=：]\s*[\"']?)(1\d{2})\d{4}(\d{4})")
+_BARE_PHONE_VALUE = re.compile(r"(?<!\d)(1\d{2})\d{4}(\d{4})(?!\d)")
+
+
+def redact_sensitive_text(value: object) -> str:
+    """Return a redacted log copy without mutating the source value."""
+    if value is None:
+        return ""
+
+    text = str(value)
+    text = _QUOTED_ARRAY_VALUE.sub(rf'\1"{REDACTED}"\2', text)
+    text = _QUOTED_VALUE.sub(rf"\1{REDACTED}\3", text)
+    text = _COOKIE_HEADER.sub(rf"\1{REDACTED}", text)
+    text = _BEARER_VALUE.sub(rf"\1{REDACTED}", text)
+    text = _QUERY_API_KEY.sub(rf"\1{REDACTED}", text)
+    text = _LABEL_VALUE.sub(rf"\1{REDACTED}", text)
+    text = _CHINESE_SECRET_VALUE.sub(rf"\1{REDACTED}", text)
+    text = _PHONE_VALUE.sub(r"\1\2****\3", text)
+    return _BARE_PHONE_VALUE.sub(r"\1****\2", text)
+
+
+class SensitiveDataFilter(logging.Filter):
+    """Redact the rendered message while leaving application objects unchanged."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            if record.exc_info:
+                # All standard formatters reuse exc_text when it is present.
+                # Populate a sanitized copy so external handlers cannot emit the raw error.
+                formatter = logging.Formatter()
+                record.exc_text = redact_sensitive_text(formatter.formatException(record.exc_info))
+
+            if record.name == "uvicorn.access" and isinstance(record.args, tuple):
+                # AccessFormatter unpacks its five arguments while rendering.
+                # Preserve that contract and sanitize only the copied strings.
+                record.args = tuple(
+                    redact_sensitive_text(item) if isinstance(item, str) else item for item in record.args
+                )
+                return True
+
+            record.msg = redact_sensitive_text(record.getMessage())
+            record.args = ()
+        except Exception:
+            # Logging must never break the application request path.
+            record.msg = "[log message unavailable]"
+            record.args = ()
+        return True
+
+
+class SensitiveFormatter(logging.Formatter):
+    """Also redact exception text emitted by application handlers."""
+
+    def formatException(self, exc_info) -> str:  # noqa: N802
+        return redact_sensitive_text(super().formatException(exc_info))

--- a/backend/openapi-service/tests/test_sensitive_logging.py
+++ b/backend/openapi-service/tests/test_sensitive_logging.py
@@ -1,0 +1,185 @@
+import logging
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from uvicorn.logging import AccessFormatter
+
+os.environ.setdefault("DATABASE_URL", "mysql+aiomysql://test:test@localhost:3306/test")
+os.environ.setdefault("DATABASE_USERNAME", "test")
+os.environ.setdefault("DATABASE_PASSWORD", "test")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+from app.schemas.api_key import ApiKeyCreate
+from app.services.api_key import ApiKeyService
+from app.services.websocket import ws_log
+from app.utils.api_key import APIKeyUtils
+from app.utils.sensitive_logging import SensitiveDataFilter, SensitiveFormatter, redact_sensitive_text
+
+
+@pytest.mark.parametrize(
+    ("source", "secrets", "expected"),
+    [
+        (
+            '{"password":"secret password","access_token":"token-123","status":200}',
+            ("secret password", "token-123"),
+            '"status":200',
+        ),
+        (
+            '{"password":["first-secret","second-secret"],"status":200}',
+            ("first-secret", "second-secret"),
+            '"password":["[REDACTED]"]',
+        ),
+        (
+            "Authorization: Bearer bearer-secret",
+            ("bearer-secret",),
+            "Authorization: [REDACTED]",
+        ),
+        (
+            "/mcp?key=query-secret&mode=list",
+            ("query-secret",),
+            "?key=[REDACTED]&mode=list",
+        ),
+        (
+            "phone: 13800138000",
+            ("13800138000",),
+            "phone: 138****8000",
+        ),
+        (
+            "keyword: 13800138000, 密码：chinese-secret",
+            ("13800138000", "chinese-secret"),
+            "keyword: 138****8000",
+        ),
+        (
+            "cacheKey: auth:temp_token:temporary-secret",
+            ("temporary-secret",),
+            "cacheKey: [REDACTED]",
+        ),
+    ],
+)
+def test_redact_sensitive_text(source, secrets, expected):
+    sanitized = redact_sensitive_text(source)
+
+    assert expected in sanitized
+    for secret in secrets:
+        assert secret not in sanitized
+
+
+def test_sensitive_filter_redacts_rendered_message_without_mutating_source():
+    payload = {"password": "secret", "phone": "13800138000", "status": "ok"}
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="payload=%s",
+        args=(payload,),
+        exc_info=None,
+    )
+
+    assert SensitiveDataFilter().filter(record) is True
+    rendered = record.getMessage()
+
+    assert "secret" not in rendered
+    assert "13800138000" not in rendered
+    assert payload == {"password": "secret", "phone": "13800138000", "status": "ok"}
+
+
+def test_sensitive_formatter_redacts_exception_text():
+    try:
+        raise RuntimeError("access_token=exception-secret")
+    except RuntimeError:
+        exception_text = SensitiveFormatter().formatException(sys.exc_info())
+
+    assert "exception-secret" not in exception_text
+    assert "access_token=[REDACTED]" in exception_text
+
+
+def test_sensitive_filter_preserves_uvicorn_access_formatter_contract():
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:12345", "GET", "/mcp?key=access-secret", "1.1", 200),
+        exc_info=None,
+    )
+
+    assert SensitiveDataFilter().filter(record) is True
+    rendered = AccessFormatter("%(message)s").format(record)
+
+    assert "access-secret" not in rendered
+    assert "/mcp?key=[REDACTED]" in rendered
+    assert record.args[-1] == 200
+
+
+def test_sensitive_filter_redacts_exception_for_external_formatter():
+    try:
+        raise RuntimeError("session_id=exception-session-secret")
+    except RuntimeError:
+        record = logging.LogRecord(
+            name="uvicorn.error",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="Request failed",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+
+    assert SensitiveDataFilter().filter(record) is True
+    rendered = logging.Formatter("%(message)s").format(record)
+
+    assert "exception-session-secret" not in rendered
+    assert "session_id=[REDACTED]" in rendered
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        ('>>>{"custom_input":"outbound-secret"}',),
+        ('<<<{"custom_output":"inbound-secret"}',),
+        ('error ExitMsg: {"custom_input":"error-secret"}',),
+    ],
+)
+def test_websocket_log_callback_does_not_log_message_payload(monkeypatch, message):
+    log_methods = (MagicMock(), MagicMock(), MagicMock())
+    monkeypatch.setattr("app.services.websocket.logger.debug", log_methods[0])
+    monkeypatch.setattr("app.services.websocket.logger.info", log_methods[1])
+    monkeypatch.setattr("app.services.websocket.logger.warning", log_methods[2])
+
+    ws_log(message)
+
+    calls = [call for method in log_methods for call in method.call_args_list]
+    assert len(calls) == 1
+    assert all("secret" not in str(call) for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_api_key_creation_returns_key_without_logging_it(monkeypatch):
+    raw_key = "raw-generated-api-key"
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    service = ApiKeyService(db)
+    service._invalidate_api_keys_cache = AsyncMock()
+    log_info = MagicMock()
+
+    monkeypatch.setattr(APIKeyUtils, "generate_api_key", MagicMock(return_value=raw_key))
+    monkeypatch.setattr(APIKeyUtils, "hash_api_key", MagicMock(return_value="stored-hash"))
+    monkeypatch.setattr("app.services.api_key.logger.info", log_info)
+
+    result = await service.create_api_key(ApiKeyCreate(name="test-key"), "user-1")
+
+    assert result == raw_key
+    assert all(raw_key not in str(call) for call in log_info.call_args_list)
+
+
+def test_api_key_verification_does_not_change_behavior():
+    raw_key = "verification-key"
+    hashed_key = APIKeyUtils.hash_api_key(raw_key)
+
+    assert APIKeyUtils.verify_api_key(raw_key, hashed_key) is True
+    assert APIKeyUtils.verify_api_key("wrong-key", hashed_key) is False

--- a/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/conf/RequestLoggingFilter.java
+++ b/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/conf/RequestLoggingFilter.java
@@ -2,6 +2,7 @@ package com.iflytek.rpa.auth.conf;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iflytek.rpa.auth.utils.SensitiveDataSanitizer;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -49,7 +50,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
         long startTime = System.currentTimeMillis();
         String path = requestWrapper.getRequestURI();
         String method = requestWrapper.getMethod();
-        String query = StringUtils.defaultString(requestWrapper.getQueryString(), "");
+        String query = SensitiveDataSanitizer.sanitize(
+                StringUtils.defaultString(requestWrapper.getQueryString(), ""));
         String startTimeText = LocalDateTime.now().format(TIME_FORMATTER);
         boolean hasException = false;
         Exception capturedException = null;
@@ -67,15 +69,17 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
                     method,
                     path,
                     duration,
-                    ex.getMessage(),
+                    SensitiveDataSanitizer.sanitize(ex.getMessage()),
                     ex);
             throw ex;
         } finally {
             long duration = System.currentTimeMillis() - startTime;
-            String reqBody =
-                    shouldLogBody(requestWrapper.getContentType()) ? getRequestBody(requestWrapper) : "[ignored]";
-            String respBody =
-                    shouldLogBody(responseWrapper.getContentType()) ? getResponseBody(responseWrapper) : "[ignored]";
+            String reqBody = shouldLogBody(requestWrapper.getContentType())
+                    ? SensitiveDataSanitizer.sanitize(getRequestBody(requestWrapper))
+                    : "[ignored]";
+            String respBody = shouldLogBody(responseWrapper.getContentType())
+                    ? SensitiveDataSanitizer.sanitize(getResponseBody(responseWrapper))
+                    : "[ignored]";
 
             log.info(
                     "{} requestId={} time={} method={} path={} query={} params={} reqBody={} duration={}ms hasException={}",
@@ -85,7 +89,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
                     method,
                     path,
                     query,
-                    truncate(buildParameterJson(requestWrapper)),
+                    truncate(SensitiveDataSanitizer.sanitize(buildParameterJson(requestWrapper))),
                     truncate(reqBody),
                     duration,
                     hasException);
@@ -100,7 +104,9 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
                     duration,
                     truncate(respBody),
                     hasException,
-                    capturedException == null ? "" : truncate(capturedException.getMessage()));
+                    capturedException == null
+                            ? ""
+                            : truncate(SensitiveDataSanitizer.sanitize(capturedException.getMessage())));
 
             responseWrapper.copyBodyToResponse();
             MDC.remove(REQUEST_ID_KEY);

--- a/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/conf/SensitiveMessageConverter.java
+++ b/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/conf/SensitiveMessageConverter.java
@@ -1,0 +1,14 @@
+package com.iflytek.rpa.auth.conf;
+
+import ch.qos.logback.classic.pattern.ClassicConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.iflytek.rpa.auth.utils.SensitiveDataSanitizer;
+
+/** Applies the central redaction policy to every formatted rpa-auth log message. */
+public class SensitiveMessageConverter extends ClassicConverter {
+
+    @Override
+    public String convert(ILoggingEvent event) {
+        return SensitiveDataSanitizer.sanitize(event.getFormattedMessage());
+    }
+}

--- a/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/conf/SensitiveThrowableConverter.java
+++ b/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/conf/SensitiveThrowableConverter.java
@@ -1,0 +1,14 @@
+package com.iflytek.rpa.auth.conf;
+
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.iflytek.rpa.auth.utils.SensitiveDataSanitizer;
+
+/** Preserves stack traces while redacting credentials from exception text. */
+public class SensitiveThrowableConverter extends ThrowableProxyConverter {
+
+    @Override
+    public String convert(ILoggingEvent event) {
+        return SensitiveDataSanitizer.sanitize(super.convert(event));
+    }
+}

--- a/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/utils/SensitiveDataSanitizer.java
+++ b/backend/rpa-auth/src/main/java/com/iflytek/rpa/auth/utils/SensitiveDataSanitizer.java
@@ -1,0 +1,64 @@
+package com.iflytek.rpa.auth.utils;
+
+import java.util.regex.Pattern;
+
+/** Creates a sanitized copy of log text without changing request, response, or DTO objects. */
+public final class SensitiveDataSanitizer {
+
+    public static final String REDACTED = "[REDACTED]";
+
+    private static final String SENSITIVE_KEY =
+            "(?:api[ _-]?key|api[ _-]?secret|hashed[ _-]?key|password|passwd|pwd|"
+                    + "confirm[ _-]?password|old[ _-]?password|new[ _-]?password|"
+                    + "access[ _-]?token|refresh[ _-]?token|id[ _-]?token|temp[ _-]?token|token|"
+                    + "authorization|cookie|cache[ _-]?key|session(?:[ _-]?id)?|jsessionid|"
+                    + "casdoor[ _-]?session[ _-]?id|"
+                    + "verification[ _-]?code|verify[ _-]?code|sms[ _-]?code|captcha|credential)";
+
+    private static final Pattern QUOTED_VALUE = Pattern.compile(
+            "([\"']" + SENSITIVE_KEY + "[\"']\\s*[:=]\\s*[\"'])(.*?)([\"'])",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern QUOTED_ARRAY_VALUE = Pattern.compile(
+            "([\"']" + SENSITIVE_KEY + "[\"']\\s*[:=]\\s*\\[)[^\\]]*(\\])",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern LABEL_VALUE = Pattern.compile(
+            "(\\b" + SENSITIVE_KEY + "\\b\\s*[:=：]\\s*)(?!\\[REDACTED\\])([^\\s,;&}\\]]+)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern CHINESE_SECRET_VALUE = Pattern.compile(
+            "((?:临时凭证|验证码|密码|口令|访问令牌|刷新令牌|会话(?:\\s*ID)?|密钥)"
+                    + "\\s*[:=：]\\s*)(?!\\[REDACTED\\])([^\\s,，；}\\]]+)");
+    private static final Pattern BEARER_VALUE =
+            Pattern.compile("(\\bBearer\\s+)([^\\s,;]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern QUERY_API_KEY =
+            Pattern.compile("([?&]key=)([^&\\s]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern COOKIE_HEADER =
+            Pattern.compile("(\\bCookie(?:\\s+header)?\\s*[:=]\\s*)([^\\r\\n]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PHONE_VALUE = Pattern.compile(
+            "((?:phone|mobile|手机号)\\s*[\"']?\\s*[:=：]\\s*[\"']?)(1\\d{2})\\d{4}(\\d{4})",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern BARE_PHONE_VALUE =
+            Pattern.compile("(?<!\\d)(1\\d{2})\\d{4}(\\d{4})(?!\\d)");
+
+    private SensitiveDataSanitizer() {}
+
+    public static String sanitize(Object source) {
+        if (source == null) {
+            return "";
+        }
+
+        String sanitized = source.toString();
+        sanitized = replace(QUOTED_ARRAY_VALUE, sanitized, "$1\"" + REDACTED + "\"$2");
+        sanitized = replace(QUOTED_VALUE, sanitized, "$1" + REDACTED + "$3");
+        sanitized = replace(COOKIE_HEADER, sanitized, "$1" + REDACTED);
+        sanitized = replace(BEARER_VALUE, sanitized, "$1" + REDACTED);
+        sanitized = replace(QUERY_API_KEY, sanitized, "$1" + REDACTED);
+        sanitized = replace(LABEL_VALUE, sanitized, "$1" + REDACTED);
+        sanitized = replace(CHINESE_SECRET_VALUE, sanitized, "$1" + REDACTED);
+        sanitized = replace(PHONE_VALUE, sanitized, "$1$2****$3");
+        return replace(BARE_PHONE_VALUE, sanitized, "$1****$2");
+    }
+
+    private static String replace(Pattern pattern, String source, String replacement) {
+        return pattern.matcher(source).replaceAll(replacement);
+    }
+}

--- a/backend/rpa-auth/src/main/resources/logback-delayed.xml
+++ b/backend/rpa-auth/src/main/resources/logback-delayed.xml
@@ -3,6 +3,10 @@
     <!-- 设置变量 -->
     <springProperty scope="context" name="logLevel" source="log.file.level" defaultValue="info"/>
     <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="none"/>
+    <conversionRule conversionWord="maskedMsg"
+                    converterClass="com.iflytek.rpa.auth.conf.SensitiveMessageConverter"/>
+    <conversionRule conversionWord="maskedEx"
+                    converterClass="com.iflytek.rpa.auth.conf.SensitiveThrowableConverter"/>
 
     <!--设置日志输出为控制台-->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -13,7 +17,7 @@
         <encoder charset="UTF-8">
             <!--格式化输出: %d表示日期, Asia/Shanghai:设置时区, %thread:表示线程名, %-5level:级别从左显示5个字符宽度, %msg:日志消息, %n:是换行符 -->
             <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Shanghai} %green([%thread]) %yellow(${PID}) %highlight(%-5level)
-                %boldMagenta(%logger{10}.%M\(%F:%L\))- %cyan(%msg%n)
+                %boldMagenta(%logger{10}.%M\(%F:%L\))- %cyan(%maskedMsg)%maskedEx%n
             </pattern>
 
         </encoder>
@@ -26,7 +30,7 @@
         </filter>
 
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>%d{HH:mm:ss.SSS,Asia/Shanghai} [%thread] %-5level %logger{32} - %msg%n</Pattern>
+            <Pattern>%d{HH:mm:ss.SSS,Asia/Shanghai} [%thread] %-5level %logger{32} - %maskedMsg%maskedEx%n</Pattern>
         </layout>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">

--- a/backend/rpa-auth/src/test/java/com/iflytek/rpa/auth/conf/RequestLoggingFilterTest.java
+++ b/backend/rpa-auth/src/test/java/com/iflytek/rpa/auth/conf/RequestLoggingFilterTest.java
@@ -1,0 +1,60 @@
+package com.iflytek.rpa.auth.conf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.util.StreamUtils;
+
+class RequestLoggingFilterTest {
+
+    @Test
+    void logsSanitizedCopiesWithoutChangingRequestOrResponse() throws Exception {
+        String requestBody = "{\"password\":\"request-secret\",\"phone\":\"13800138000\"}";
+        String responseBody = "{\"access_token\":\"response-secret\",\"status\":\"ok\"}";
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/login");
+        request.setQueryString("tempToken=query-secret&mode=login");
+        request.addParameter("password", "parameter-secret");
+        request.setContentType("application/json");
+        request.setContent(requestBody.getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        Logger logger = (Logger) LoggerFactory.getLogger(RequestLoggingFilter.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            new RequestLoggingFilter().doFilter(request, response, (servletRequest, servletResponse) -> {
+                StreamUtils.copyToString(servletRequest.getInputStream(), StandardCharsets.UTF_8);
+                servletResponse.setContentType("application/json");
+                servletResponse.getWriter().write(responseBody);
+            });
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+
+        String logs = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.joining("\n"));
+
+        assertFalse(logs.contains("request-secret"));
+        assertFalse(logs.contains("response-secret"));
+        assertFalse(logs.contains("query-secret"));
+        assertFalse(logs.contains("parameter-secret"));
+        assertFalse(logs.contains("13800138000"));
+        assertTrue(logs.contains("138****8000"));
+        assertEquals(responseBody, response.getContentAsString());
+        assertEquals("parameter-secret", request.getParameter("password"));
+    }
+}

--- a/backend/rpa-auth/src/test/java/com/iflytek/rpa/auth/utils/SensitiveDataSanitizerTest.java
+++ b/backend/rpa-auth/src/test/java/com/iflytek/rpa/auth/utils/SensitiveDataSanitizerTest.java
@@ -1,0 +1,87 @@
+package com.iflytek.rpa.auth.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import com.iflytek.rpa.auth.conf.SensitiveMessageConverter;
+import com.iflytek.rpa.auth.conf.SensitiveThrowableConverter;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+class SensitiveDataSanitizerTest {
+
+    @Test
+    void redactsStructuredCredentialsAndPreservesNonSensitiveFields() {
+        String source = "{\"password\":\"secret password\",\"access_token\":\"token-123\","
+                + "\"refresh_token\":[\"refresh-secret\"],\"status\":200}";
+
+        String sanitized = SensitiveDataSanitizer.sanitize(source);
+
+        assertFalse(sanitized.contains("secret password"));
+        assertFalse(sanitized.contains("token-123"));
+        assertFalse(sanitized.contains("refresh-secret"));
+        assertTrue(sanitized.contains("\"password\":\"[REDACTED]\""));
+        assertTrue(sanitized.contains("\"refresh_token\":[\"[REDACTED]\"]"));
+        assertTrue(sanitized.contains("\"status\":200"));
+    }
+
+    @Test
+    void redactsHeadersQueryCredentialsAndAuthenticationArtifacts() {
+        String source = "Authorization: Bearer bearer-secret Cookie: SESSION=session-secret "
+                + "uri=/mcp?key=query-secret 临时凭证：temp-secret 验证码：123456 "
+                + "cacheKey: auth:temp_token:temporary-secret";
+
+        String sanitized = SensitiveDataSanitizer.sanitize(source);
+
+        assertFalse(sanitized.contains("bearer-secret"));
+        assertFalse(sanitized.contains("session-secret"));
+        assertFalse(sanitized.contains("query-secret"));
+        assertFalse(sanitized.contains("temp-secret"));
+        assertFalse(sanitized.contains("temporary-secret"));
+        assertFalse(sanitized.contains("123456"));
+    }
+
+    @Test
+    void masksPhoneNumbersAndDoesNotMutateUnrelatedText() {
+        String source = "phone: 13800138000 keyword: 13900139000 密码：chinese-secret status=success";
+        String sanitized = SensitiveDataSanitizer.sanitize(source);
+
+        assertEquals(
+                "phone: 138****8000 keyword: 139****9000 密码：[REDACTED] status=success",
+                sanitized);
+    }
+
+    @Test
+    void logbackConvertersRedactMessagesAndThrowableText() {
+        Logger logger = (Logger) LoggerFactory.getLogger("sensitive-converter-test");
+        ILoggingEvent event = new LoggingEvent(
+                getClass().getName(),
+                logger,
+                Level.ERROR,
+                "password=message-secret",
+                new IllegalStateException("session_id=throwable-secret"),
+                null);
+
+        SensitiveMessageConverter messageConverter = new SensitiveMessageConverter();
+        SensitiveThrowableConverter throwableConverter = new SensitiveThrowableConverter();
+        messageConverter.start();
+        throwableConverter.start();
+        try {
+            String sanitizedMessage = messageConverter.convert(event);
+            String sanitizedThrowable = throwableConverter.convert(event);
+
+            assertFalse(sanitizedMessage.contains("message-secret"));
+            assertTrue(sanitizedMessage.contains("password=[REDACTED]"));
+            assertFalse(sanitizedThrowable.contains("throwable-secret"));
+            assertTrue(sanitizedThrowable.contains("session_id=[REDACTED]"));
+        } finally {
+            messageConverter.stop();
+            throwableConverter.stop();
+        }
+    }
+}

--- a/docker/volumes/nginx/default.conf
+++ b/docker/volumes/nginx/default.conf
@@ -41,9 +41,17 @@ upstream casdoor {
     keepalive 32;
 }
 
+# Keep request diagnostics without logging query parameters. This prevents
+# legacy MCP ?key= credentials and other sensitive query values from entering
+# the nginx access log.
+log_format sanitized_access '$remote_addr - $remote_user [$time_local] '
+                            '"$request_method $uri $server_protocol" $status $body_bytes_sent '
+                            '"$http_user_agent" request_time=$request_time';
+
 server {
     listen 80;
     server_name localhost;
+    access_log /usr/local/openresty/nginx/logs/access.log sanitized_access;
 
     # 通用配置
     client_max_body_size 100M;

--- a/docker/volumes/nginx/lua/auth_handler.lua
+++ b/docker/volumes/nginx/lua/auth_handler.lua
@@ -13,7 +13,7 @@ local ngx_HTTP_INTERNAL_SERVER_ERROR = ngx.HTTP_INTERNAL_SERVER_ERROR
 -- 定义一个函数来处理认证逻辑
 local function authenticate_user()
     local ctx_type = ngx.var.context_type or "HTTP"
-    ngx_log(ngx_DEBUG, "Starting authentication for " .. ctx_type .. " request. URI: " .. ngx.var.request_uri)
+    ngx_log(ngx_DEBUG, "Starting authentication for " .. ctx_type .. " request. URI: " .. ngx.var.uri)
 
     local session_token = nil
     local cookie_type = nil -- 记录从哪个 cookie 获取的 token (SESSION 或 JSESSIONID)
@@ -21,11 +21,10 @@ local function authenticate_user()
     -- 1. 尝试从 Authorization header 获取 Bearer Token
     local authorization_header = ngx.req.get_headers()["authorization"] -- 注意，headers 都是小写键
     if authorization_header then
-        ngx_log(ngx_DEBUG, "Found Authorization header: " .. authorization_header)
+        ngx_log(ngx_DEBUG, "Authorization header is present.")
         local _, _, token_type, token_value = string.find(authorization_header, "^(%S+)%s+(.+)$")
         if token_type and token_type:lower() == "bearer" then
             -- session_token = token_value
-            -- ngx_log(ngx_DEBUG, "Extracted Bearer Token from Authorization header: " .. session_token)
             return
         else
             ngx_log(ngx_DEBUG, "Authorization header is present but not Bearer type, type: " .. (token_type or "nil"))
@@ -40,7 +39,7 @@ local function authenticate_user()
         local custom_token_header = ngx.req.get_headers()["token"]
         if custom_token_header then
             session_token = custom_token_header
-            ngx_log(ngx_DEBUG, "Extracted Token from custom 'Token' header: " .. session_token)
+            ngx_log(ngx_DEBUG, "Extracted Token from custom 'Token' header.")
         else
             ngx_log(ngx_DEBUG, "No custom 'Token' header found.")
         end
@@ -50,19 +49,19 @@ local function authenticate_user()
     if not session_token then
         local cookie_header = ngx.var.http_cookie
         if cookie_header then
-            ngx_log(ngx_DEBUG, "Found Cookie header: " .. cookie_header)
+            ngx_log(ngx_DEBUG, "Cookie header is present.")
             -- 解析Cookie，优先查找 SESSION，然后查找 JSESSIONID
             for cookie_pair in string.gmatch(cookie_header, "[^;]+") do
                 local cookie_name, cookie_value = string.match(cookie_pair, "^%s*(.-)%s*=%s*(.-)%s*$")
                 if cookie_name == "SESSION" then
                     session_token = cookie_value
                     cookie_type = "SESSION"
-                    ngx_log(ngx_DEBUG, "Extracted Token from Cookie SESSION: " .. session_token)
+                    ngx_log(ngx_DEBUG, "Extracted Token from Cookie SESSION.")
                     break
                 elseif cookie_name == "JSESSIONID" then
                     session_token = cookie_value
                     cookie_type = "JSESSIONID"
-                    ngx_log(ngx_DEBUG, "Extracted Token from Cookie JSESSIONID: " .. session_token)
+                    ngx_log(ngx_DEBUG, "Extracted Token from Cookie JSESSIONID.")
                     break
                 end
             end
@@ -79,7 +78,7 @@ local function authenticate_user()
         local args = ngx.req.get_uri_args()
         if args.key then
             session_token = args.key
-            ngx_log(ngx_DEBUG, "Extracted Token from query parameter 'key': " .. session_token)
+            ngx_log(ngx_DEBUG, "Extracted Token from query parameter 'key'.")
         else
             ngx_log(ngx_DEBUG, "No query parameter 'key' found.")
         end
@@ -92,7 +91,7 @@ local function authenticate_user()
         return ngx.exit(ngx_HTTP_UNAUTHORIZED)
     end
 
-    ngx_log(ngx_DEBUG, "Successfully extracted session_token: '" .. session_token .. "'")
+    ngx_log(ngx_DEBUG, "Successfully extracted an authentication credential.")
 
     -- 调用 robot-service 进行认证
     local getUserUrl = "http://robot-service:8040/api/robot/user/info"
@@ -110,7 +109,7 @@ local function authenticate_user()
         ["Cookie"] = cookie_name_for_service .. "=" .. session_token
     }
 
-    ngx_log(ngx_DEBUG, "Calling robot-service (" .. getUserUrl .. ") with headers: " .. json.encode(headers_to_robot_service))
+    ngx_log(ngx_DEBUG, "Calling robot-service (" .. getUserUrl .. ") with credential cookie type: " .. cookie_name_for_service)
 
     local res, err = httpc:request_uri(getUserUrl, {
         method = "GET",
@@ -128,10 +127,10 @@ local function authenticate_user()
         return ngx.exit(ngx_HTTP_INTERNAL_SERVER_ERROR)
     end
 
-    ngx_log(ngx_DEBUG, "robot-service response status: " .. res.status .. ", body (first 200 chars): " .. (res.body and string.sub(res.body, 1, 200) or "No body"))
+    ngx_log(ngx_DEBUG, "robot-service response status: " .. res.status)
 
     if res.status ~= ngx_HTTP_OK then
-        ngx_log(ngx_ERR, "robot-service returned unexpected status " .. res.status .. " for " .. ctx_type .. " auth, full body: " .. (res.body or "No body"))
+        ngx_log(ngx_ERR, "robot-service returned unexpected status " .. res.status .. " for " .. ctx_type .. " auth")
         ngx.status = res.status
         ngx.say(res.body) -- 将 robot-service 的错误响应直接返回
         return ngx.exit(res.status)
@@ -139,20 +138,18 @@ local function authenticate_user()
 
     local userResponse, json_err = json.decode(res.body)
     if json_err then
-        ngx_log(ngx_ERR, "Failed to decode robot-service response for " .. ctx_type .. " auth: " .. json_err .. ", full body: " .. (res.body or "No body"))
+        ngx_log(ngx_ERR, "Failed to decode robot-service response for " .. ctx_type .. " auth: " .. json_err)
         ngx.status = ngx_HTTP_INTERNAL_SERVER_ERROR
         ngx.say(json.encode({code = "5000", message = "Internal Server Error: Invalid auth service response"}))
         return ngx.exit(ngx_HTTP_INTERNAL_SERVER_ERROR)
     end
-
-    ngx_log(ngx_DEBUG, "Decoded robot-service response: " .. json.encode(userResponse))
 
     -- robot-service 成功时返回 code 为 "000000" (字符串) 或 200 (数字)
     local response_code = userResponse.code
     local is_success = (response_code == "000000") or (response_code == 200) or (tostring(response_code) == "000000")
     
     if not is_success then
-        ngx_log(ngx_ERR, "robot-service returned error code: " .. (response_code or "nil") .. ", message: " .. (userResponse.message or "nil") .. " for " .. ctx_type .. " auth. Full response: " .. json.encode(userResponse))
+        ngx_log(ngx_ERR, "robot-service returned error code: " .. (response_code or "nil") .. " for " .. ctx_type .. " auth")
         ngx.status = ngx_HTTP_UNAUTHORIZED
         ngx.say(json.encode({
             code = response_code or "U_AUTH_FAIL",
@@ -164,7 +161,7 @@ local function authenticate_user()
 
     local user_id = userResponse.data and userResponse.data["id"]
     if not user_id then
-        ngx_log(ngx_ERR, "robot-service response missing 'id' in 'data' field for " .. ctx_type .. " auth: " .. json.encode(userResponse))
+        ngx_log(ngx_ERR, "robot-service response missing 'id' in 'data' field for " .. ctx_type .. " auth")
         ngx.status = ngx_HTTP_INTERNAL_SERVER_ERROR
         ngx.say(json.encode({code = "5000", message = "Internal Server Error: Auth service response missing user_id"}))
         return ngx.exit(ngx_HTTP_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
This closes #855.

## 变更内容 | Changes Made

### OpenAPI

- 新增统一敏感日志过滤器和异常格式化器。
- 脱敏以下内容：
  - API Key、API Secret 和 bcrypt 哈希。
  - Authorization Bearer、Token、Cookie 和 Session。
  - 密码、验证码、临时凭证和认证信息。
  - 手机号。
  - JSON 标量及数组形式的敏感字段。
- 将脱敏过滤器应用于应用日志及 Uvicorn access/error 日志。
- 保留 Uvicorn `AccessFormatter` 的参数结构，避免影响访问日志格式化。
- 创建 API Key 时不记录完整明文 Key。
- 校验 API Key 时不记录输入 Key 和 bcrypt 哈希。
- MCP 鉴权失败消息不包含请求中的原始 Key。
- 不记录完整工作流参数、执行结果、WebSocket 收发正文和外部认证响应正文。
- WebSocket 日志仅保留发送、接收、连接和错误等事件类型。

### rpa-auth

- 新增统一的 `SensitiveDataSanitizer`。
- query、params、请求体、响应体和异常消息只记录脱敏后的副本。
- 脱敏处理不修改真实请求、响应或 DTO。
- 新增 Logback message 和 throwable converter。
- 控制台日志、文件日志及异常堆栈统一脱敏处理。
- Token、密码、Cookie、Session、验证码、临时凭证、手机号及数组参数脱敏。

### nginx / OpenResty

- 新增 `sanitized_access` 日志格式。
- 使用不包含查询参数的 `$uri`，避免 `?key=` 等敏感参数进入 access log。
- 移除 Referer 字段，避免 Referer 中的查询参数进入日志。
- Lua 认证日志不再输出：
  - Authorization Header。
  - Token Header。
  - Cookie、SESSION 和 JSESSIONID。
  - URL `?key=` 的值。
  - 转发至认证服务的凭据。
  - 认证响应正文及完整用户响应。
- 保留请求方法、URI、状态码、响应大小、User-Agent 和耗时等排障信息。
- 未修改认证来源优先级、认证请求、响应转发及用户 Header 注入逻辑。

## 测试

### 测试结果

- OpenAPI 敏感日志 UT：`16 passed`
- rpa-auth Maven UT：`5 passed`
- rpa-auth 构建结果：`BUILD SUCCESS`
- Python Ruff 格式检查：通过
- Python Ruff 语法及未使用变量检查：通过
- Logback XML 解析：通过
- Lua 5.1 `luac -p` 语法检查：通过
- nginx 配置结构检查：通过
- Lua 敏感变量日志静态扫描：通过
- `git diff --check`：通过

- 受运行环境影响限制，未运行`nginx -t`验证Nginx配置的正确性，未完成Docker Compose 集成测试