### PR TITLE
fix:修复工作流发布同步及 MCP 工具发现链路

### DIFF
--- a/backend/openapi-service/tests/services/test_streamable_mcp.py
+++ b/backend/openapi-service/tests/services/test_streamable_mcp.py
@@ -1,0 +1,58 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.streamable_mcp import ToolsConfig
+
+
+@pytest.mark.asyncio
+async def test_published_workflow_is_exposed_as_mcp_tool(monkeypatch):
+    tools_config = ToolsConfig()
+
+    async def get_published_workflows(user_id: str):
+        assert user_id == "user-1"
+        return [
+            {
+                "project_id": "robot-1",
+                "name": "Invoice Bot",
+                "english_name": "invoice_bot",
+                "description": "Process invoices",
+                "version": 3,
+                "status": 1,
+                "parameters": [],
+            }
+        ]
+
+    monkeypatch.setattr(tools_config, "get_user_workflows", get_published_workflows)
+
+    tools = await tools_config.get_tools_for_user("user-1")
+
+    assert len(tools) == 1
+    assert tools[0].name == "invoice_bot"
+    assert tools[0].description == "Process invoices"
+    assert tools[0].inputSchema == {"type": "object"}
+
+
+@pytest.mark.asyncio
+async def test_workflow_lookup_uses_authenticated_user(monkeypatch):
+    tools_config = ToolsConfig()
+    workflow = type(
+        "WorkflowStub",
+        (),
+        {"to_dict": lambda self: {"project_id": "robot-1", "status": 1}},
+    )()
+    workflow_service = type("WorkflowServiceStub", (), {})()
+    workflow_service.get_workflows = AsyncMock(return_value=[workflow])
+    db = type("DatabaseSessionStub", (), {})()
+    db.close = AsyncMock()
+
+    async def get_workflow_service():
+        return workflow_service, db
+
+    monkeypatch.setattr(tools_config, "_get_workflow_service", get_workflow_service)
+
+    workflows = await tools_config.get_user_workflows("authenticated-user")
+
+    workflow_service.get_workflows.assert_awaited_once_with("authenticated-user")
+    db.close.assert_awaited_once()
+    assert workflows == [{"project_id": "robot-1", "status": 1}]

--- a/backend/openapi-service/tests/services/test_workflow.py
+++ b/backend/openapi-service/tests/services/test_workflow.py
@@ -1,0 +1,23 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.workflow import WorkflowService
+
+
+@pytest.mark.asyncio
+async def test_get_workflows_filters_by_active_status_and_user():
+    result = type("ResultStub", (), {})()
+    scalars = type("ScalarsStub", (), {})()
+    scalars.all = lambda: []
+    result.scalars = lambda: scalars
+    db = type("DatabaseSessionStub", (), {})()
+    db.execute = AsyncMock(return_value=result)
+    service = WorkflowService(db)
+
+    assert await service.get_workflows("user-1") == []
+
+    statement = db.execute.await_args.args[0]
+    sql = str(statement.compile(compile_kwargs={"literal_binds": True}))
+    assert "workflows.status = 1" in sql
+    assert "workflows.user_id = 'user-1'" in sql

--- a/backend/robot-service/src/main/java/com/iflytek/rpa/example/config/OpenApiProperties.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/example/config/OpenApiProperties.java
@@ -1,0 +1,24 @@
+package com.iflytek.rpa.example.config;
+
+import com.iflytek.rpa.example.constants.ExampleConstants;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "openapi")
+public class OpenApiProperties {
+
+    private String workflowsUpsertUrl = ExampleConstants.WORKFLOWS_UPSERT_URL;
+
+    public String getWorkflowsUpsertUrl() {
+        return workflowsUpsertUrl;
+    }
+
+    public void setWorkflowsUpsertUrl(String workflowsUpsertUrl) {
+        if (workflowsUpsertUrl == null || workflowsUpsertUrl.trim().isEmpty()) {
+            this.workflowsUpsertUrl = ExampleConstants.WORKFLOWS_UPSERT_URL;
+            return;
+        }
+        this.workflowsUpsertUrl = workflowsUpsertUrl;
+    }
+}

--- a/backend/robot-service/src/main/java/com/iflytek/rpa/example/entity/Dto/WorkflowsUpsertDto.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/example/entity/Dto/WorkflowsUpsertDto.java
@@ -12,4 +12,24 @@ public class WorkflowsUpsertDto {
     Integer status;
     String parameters;
     String example_project_id;
+
+    public static WorkflowsUpsertDto published(
+            String projectId,
+            String name,
+            String description,
+            Integer version,
+            String parameters,
+            String exampleProjectId) {
+        WorkflowsUpsertDto workflow = new WorkflowsUpsertDto();
+        String workflowName = name == null || name.trim().isEmpty() ? projectId : name;
+        workflow.setProject_id(projectId);
+        workflow.setName(workflowName);
+        workflow.setEnglish_name(workflowName);
+        workflow.setDescription(description);
+        workflow.setVersion(version);
+        workflow.setStatus(1);
+        workflow.setParameters(parameters);
+        workflow.setExample_project_id(exampleProjectId);
+        return workflow;
+    }
 }

--- a/backend/robot-service/src/main/java/com/iflytek/rpa/example/service/impl/SampleUsersServiceImpl.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/example/service/impl/SampleUsersServiceImpl.java
@@ -1,6 +1,5 @@
 package com.iflytek.rpa.example.service.impl;
 
-import static com.iflytek.rpa.example.constants.ExampleConstants.WORKFLOWS_UPSERT_URL;
 import static com.iflytek.rpa.robot.constants.RobotConstant.EXECUTOR;
 
 import com.alibaba.fastjson.JSON;
@@ -19,6 +18,7 @@ import com.iflytek.rpa.base.entity.CProcess;
 import com.iflytek.rpa.base.entity.dto.ParamDto;
 import com.iflytek.rpa.base.entity.dto.QueryParamDto;
 import com.iflytek.rpa.base.service.handler.ExecutorModeHandler;
+import com.iflytek.rpa.example.config.OpenApiProperties;
 import com.iflytek.rpa.example.constants.ExampleConstants;
 import com.iflytek.rpa.example.dao.SampleTemplatesDao;
 import com.iflytek.rpa.example.dao.SampleUsersDao;
@@ -96,6 +96,9 @@ public class SampleUsersServiceImpl extends ServiceImpl<SampleUsersDao, SampleUs
 
     @Autowired
     private IdWorker idWorker;
+
+    @Autowired
+    private OpenApiProperties openApiProperties;
 
     @Value("${example.expoUserId}")
     private String expoUserId;
@@ -176,17 +179,20 @@ public class SampleUsersServiceImpl extends ServiceImpl<SampleUsersDao, SampleUs
         String parameters = JSON.toJSONString(responseData);
         log.info("新的机器人参数如下：" + parameters);
 
-        WorkflowsUpsertDto requestDto = new WorkflowsUpsertDto();
-        requestDto.setProject_id(robotId);
-        requestDto.setVersion(version);
-        requestDto.setParameters(parameters);
+        RobotExecute robotExecute = robotExecuteDao.getRobotExecute(robotId, userId, tenantId);
+        String workflowName = robotExecute == null ? robotId : robotExecute.getName();
+        if (robotExecute == null || StringUtils.isBlank(robotExecute.getName())) {
+            log.warn("Robot name is unavailable during OpenAPI sync; using robotId as fallback: {}", robotId);
+        }
+        WorkflowsUpsertDto requestDto =
+                WorkflowsUpsertDto.published(robotId, workflowName, "", version, parameters, null);
 
         // 将 requestDto 转换为 JSON 字符串
         String requestBody = JSONObject.toJSONString(requestDto);
         log.info("请求openapi参数:" + requestBody);
 
         // 创建 RestTemplate 实例
-        RestTemplate restTemplate = new RestTemplate();
+        RestTemplate restTemplate = createRestTemplate();
 
         // 设置请求头
         HttpHeaders headers = new HttpHeaders();
@@ -199,16 +205,17 @@ public class SampleUsersServiceImpl extends ServiceImpl<SampleUsersDao, SampleUs
 
         // 发起 POST 请求
         try {
+            String workflowsUpsertUrl = openApiProperties.getWorkflowsUpsertUrl();
             ResponseEntity<String> response =
-                    restTemplate.exchange(WORKFLOWS_UPSERT_URL, HttpMethod.POST, requestEntity, String.class);
+                    restTemplate.exchange(workflowsUpsertUrl, HttpMethod.POST, requestEntity, String.class);
 
             log.info(
                     "OpenAPI 请求成功，URL: {}, 响应状态: {}, 响应体: {}",
-                    WORKFLOWS_UPSERT_URL,
+                    workflowsUpsertUrl,
                     response.getStatusCode(),
                     response.getBody());
         } catch (Exception e) {
-            log.error("OpenAPI 请求失败，URL: {}, 错误信息: {}", WORKFLOWS_UPSERT_URL, e.getMessage(), e);
+            log.error("OpenAPI 请求失败，URL: {}, 错误信息: {}", openApiProperties.getWorkflowsUpsertUrl(), e.getMessage(), e);
             throw e;
         }
     }
@@ -412,22 +419,20 @@ public class SampleUsersServiceImpl extends ServiceImpl<SampleUsersDao, SampleUs
         String parameters = JSON.toJSONString(responseData);
         log.info("robot params are as follows:" + parameters);
 
-        WorkflowsUpsertDto requestDto = new WorkflowsUpsertDto();
-        requestDto.setProject_id(robotExecute.getRobotId());
-        requestDto.setName(robotExecute.getName());
-        requestDto.setEnglish_name(robotExecute.getName());
-        requestDto.setDescription("");
-        requestDto.setVersion(robotExecute.getRobotVersion());
-        requestDto.setStatus(1);
-        requestDto.setParameters(parameters);
-        requestDto.setExample_project_id(expoUserRobotId);
+        WorkflowsUpsertDto requestDto = WorkflowsUpsertDto.published(
+                robotExecute.getRobotId(),
+                robotExecute.getName(),
+                "",
+                robotExecute.getRobotVersion(),
+                parameters,
+                expoUserRobotId);
 
         // 将 requestDto 转换为 JSON 字符串
         String requestBody = JSONObject.toJSONString(requestDto);
         log.info("请求openapi参数:" + requestBody);
 
         // 创建 RestTemplate 实例
-        RestTemplate restTemplate = new RestTemplate();
+        RestTemplate restTemplate = createRestTemplate();
 
         // 设置请求头
         HttpHeaders headers = new HttpHeaders();
@@ -440,18 +445,23 @@ public class SampleUsersServiceImpl extends ServiceImpl<SampleUsersDao, SampleUs
 
         // 发起 POST 请求
         try {
+            String workflowsUpsertUrl = openApiProperties.getWorkflowsUpsertUrl();
             ResponseEntity<String> response =
-                    restTemplate.exchange(WORKFLOWS_UPSERT_URL, HttpMethod.POST, requestEntity, String.class);
+                    restTemplate.exchange(workflowsUpsertUrl, HttpMethod.POST, requestEntity, String.class);
 
             log.info(
                     "OpenAPI 请求成功，URL: {}, 响应状态: {}, 响应体: {}",
-                    WORKFLOWS_UPSERT_URL,
+                    workflowsUpsertUrl,
                     response.getStatusCode(),
                     response.getBody());
         } catch (Exception e) {
-            log.error("OpenAPI 请求失败，URL: {}, 错误信息: {}", WORKFLOWS_UPSERT_URL, e.getMessage(), e);
+            log.error("OpenAPI 请求失败，URL: {}, 错误信息: {}", openApiProperties.getWorkflowsUpsertUrl(), e.getMessage(), e);
             throw e;
         }
+    }
+
+    RestTemplate createRestTemplate() {
+        return new RestTemplate();
     }
 
     /**

--- a/backend/robot-service/src/main/java/com/iflytek/rpa/robot/service/impl/RobotDesignServiceImpl.java
+++ b/backend/robot-service/src/main/java/com/iflytek/rpa/robot/service/impl/RobotDesignServiceImpl.java
@@ -16,7 +16,7 @@ import com.iflytek.rpa.component.dao.ComponentRobotBlockDao;
 import com.iflytek.rpa.component.dao.ComponentRobotUseDao;
 import com.iflytek.rpa.component.entity.ComponentRobotBlock;
 import com.iflytek.rpa.component.entity.ComponentRobotUse;
-import com.iflytek.rpa.example.constants.ExampleConstants;
+import com.iflytek.rpa.example.config.OpenApiProperties;
 import com.iflytek.rpa.market.entity.vo.AcceptResultVo;
 import com.iflytek.rpa.market.entity.vo.LatestVersionRobotVo;
 import com.iflytek.rpa.market.service.AppApplicationService;
@@ -130,6 +130,9 @@ public class RobotDesignServiceImpl extends ServiceImpl<RobotDesignDao, RobotDes
 
     @Autowired
     private QuotaCheckService quotaCheckService;
+
+    @Autowired
+    private OpenApiProperties openApiProperties;
 
     @Override
     @Transactional(rollbackFor = Exception.class)
@@ -620,7 +623,7 @@ public class RobotDesignServiceImpl extends ServiceImpl<RobotDesignDao, RobotDes
             log.info("请求openapi参数: {}", requestBodyStr);
 
             // 创建 RestTemplate 实例
-            RestTemplate restTemplate = new RestTemplate();
+            RestTemplate restTemplate = createRestTemplate();
 
             // 设置请求头
             HttpHeaders headers = new HttpHeaders();
@@ -631,7 +634,7 @@ public class RobotDesignServiceImpl extends ServiceImpl<RobotDesignDao, RobotDes
             HttpEntity<String> requestEntity = new HttpEntity<>(requestBodyStr, headers);
 
             // openapi URL
-            String openApiUrl = ExampleConstants.WORKFLOWS_UPSERT_URL;
+            String openApiUrl = openApiProperties.getWorkflowsUpsertUrl();
 
             // 发起 POST 请求
             ResponseEntity<String> response =
@@ -646,6 +649,10 @@ public class RobotDesignServiceImpl extends ServiceImpl<RobotDesignDao, RobotDes
             log.error("OpenAPI 请求失败，robotId: {}, 错误信息: {}", robotId, e.getMessage(), e);
             // 不抛出异常，避免影响删除操作
         }
+    }
+
+    RestTemplate createRestTemplate() {
+        return new RestTemplate();
     }
 
     // 后处理，查看以taskIdList为taskId的在taskRobot中还是否存在，如果不存在，则需要在schedule task表中也删除

--- a/backend/robot-service/src/test/java/com/iflytek/rpa/example/config/OpenApiPropertiesTest.java
+++ b/backend/robot-service/src/test/java/com/iflytek/rpa/example/config/OpenApiPropertiesTest.java
@@ -1,0 +1,42 @@
+package com.iflytek.rpa.example.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.iflytek.rpa.example.constants.ExampleConstants;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.mock.env.MockEnvironment;
+
+class OpenApiPropertiesTest {
+
+    @Test
+    void shouldKeepLegacyUrlAsDefault() {
+        OpenApiProperties properties = new OpenApiProperties();
+
+        assertEquals(ExampleConstants.WORKFLOWS_UPSERT_URL, properties.getWorkflowsUpsertUrl());
+    }
+
+    @Test
+    void shouldAllowDeploymentToOverrideWorkflowUpsertUrl() {
+        String configuredUrl = "http://openapi-service:8020/workflows/upsert";
+        MockEnvironment environment = new MockEnvironment().withProperty("openapi.workflows-upsert-url", configuredUrl);
+
+        OpenApiProperties properties = Binder.get(environment)
+                .bind("openapi", Bindable.of(OpenApiProperties.class))
+                .get();
+
+        assertEquals(configuredUrl, properties.getWorkflowsUpsertUrl());
+    }
+
+    @Test
+    void shouldFallBackToLegacyUrlForBlankConfiguration() {
+        OpenApiProperties properties = new OpenApiProperties();
+
+        properties.setWorkflowsUpsertUrl("  ");
+        assertEquals(ExampleConstants.WORKFLOWS_UPSERT_URL, properties.getWorkflowsUpsertUrl());
+
+        properties.setWorkflowsUpsertUrl(null);
+        assertEquals(ExampleConstants.WORKFLOWS_UPSERT_URL, properties.getWorkflowsUpsertUrl());
+    }
+}

--- a/backend/robot-service/src/test/java/com/iflytek/rpa/example/entity/Dto/WorkflowsUpsertDtoTest.java
+++ b/backend/robot-service/src/test/java/com/iflytek/rpa/example/entity/Dto/WorkflowsUpsertDtoTest.java
@@ -1,0 +1,41 @@
+package com.iflytek.rpa.example.entity.Dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class WorkflowsUpsertDtoTest {
+
+    @Test
+    void shouldCreateAnActivePublishedWorkflow() {
+        WorkflowsUpsertDto workflow = WorkflowsUpsertDto.published("robot-1", "Invoice Bot", "", 3, "[]", null);
+
+        assertEquals("robot-1", workflow.getProject_id());
+        assertEquals("Invoice Bot", workflow.getName());
+        assertEquals("Invoice Bot", workflow.getEnglish_name());
+        assertEquals("", workflow.getDescription());
+        assertEquals(3, workflow.getVersion());
+        assertEquals(1, workflow.getStatus());
+        assertEquals("[]", workflow.getParameters());
+        assertNull(workflow.getExample_project_id());
+    }
+
+    @Test
+    void shouldUseProjectIdWhenPublishedWorkflowNameIsUnavailable() {
+        WorkflowsUpsertDto workflow = WorkflowsUpsertDto.published("robot-2", " ", "", 1, "[]", null);
+
+        assertEquals("robot-2", workflow.getName());
+        assertEquals("robot-2", workflow.getEnglish_name());
+    }
+
+    @Test
+    void shouldPreserveExampleProjectMapping() {
+        WorkflowsUpsertDto workflow =
+                WorkflowsUpsertDto.published("robot-3", null, "Imported workflow", 2, "[]", "example-robot-3");
+
+        assertEquals("robot-3", workflow.getName());
+        assertEquals("Imported workflow", workflow.getDescription());
+        assertEquals("example-robot-3", workflow.getExample_project_id());
+    }
+}

--- a/backend/robot-service/src/test/java/com/iflytek/rpa/example/service/impl/SampleUsersServiceImplTest.java
+++ b/backend/robot-service/src/test/java/com/iflytek/rpa/example/service/impl/SampleUsersServiceImplTest.java
@@ -1,0 +1,187 @@
+package com.iflytek.rpa.example.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.alibaba.fastjson.JSONObject;
+import com.iflytek.rpa.base.entity.dto.ParamDto;
+import com.iflytek.rpa.base.entity.dto.QueryParamDto;
+import com.iflytek.rpa.base.service.handler.ExecutorModeHandler;
+import com.iflytek.rpa.example.config.OpenApiProperties;
+import com.iflytek.rpa.robot.dao.RobotExecuteDao;
+import com.iflytek.rpa.robot.entity.RobotExecute;
+import com.iflytek.rpa.utils.response.AppResponse;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+class SampleUsersServiceImplTest {
+
+    private static final String UPSERT_URL = "http://openapi-service:8020/workflows/upsert";
+
+    private SampleUsersServiceImpl service;
+    private RobotExecuteDao robotExecuteDao;
+    private ExecutorModeHandler executorModeHandler;
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        service = spy(new SampleUsersServiceImpl());
+        robotExecuteDao = mock(RobotExecuteDao.class);
+        executorModeHandler = mock(ExecutorModeHandler.class);
+        restTemplate = mock(RestTemplate.class);
+
+        OpenApiProperties properties = new OpenApiProperties();
+        properties.setWorkflowsUpsertUrl(UPSERT_URL);
+        ReflectionTestUtils.setField(service, "robotExecuteDao", robotExecuteDao);
+        ReflectionTestUtils.setField(service, "executorModeHandler", executorModeHandler);
+        ReflectionTestUtils.setField(service, "openApiProperties", properties);
+        ReflectionTestUtils.setField(service, "expoUserId", "example-user");
+        doReturn(restTemplate).when(service).createRestTemplate();
+    }
+
+    @Test
+    void shouldSynchronizePublishedWorkflowToConfiguredUrl() throws Exception {
+        RobotExecute robot = robot("robot-1", "Invoice Bot", 3);
+        when(robotExecuteDao.getRobotExecute("robot-1", "user-1", "tenant-1")).thenReturn(robot);
+        when(executorModeHandler.getParamInside4NewVersion(
+                        any(QueryParamDto.class), eq("user-1"), eq("tenant-1"), eq(3)))
+                .thenReturn(emptyParameters());
+        stubSuccessfulPost();
+
+        service.sendOpenApi("robot-1", 3, "user-1", "tenant-1");
+
+        HttpEntity<String> requestEntity = captureRequest("user-1");
+        JSONObject request = JSONObject.parseObject(requestEntity.getBody());
+        assertEquals("robot-1", request.getString("project_id"));
+        assertEquals("Invoice Bot", request.getString("name"));
+        assertEquals("Invoice Bot", request.getString("english_name"));
+        assertEquals(1, request.getInteger("status"));
+        assertEquals(3, request.getInteger("version"));
+        assertEquals("[]", request.getString("parameters"));
+    }
+
+    @Test
+    void shouldUseRobotIdWhenStoredNameIsBlank() throws Exception {
+        RobotExecute robot = robot("robot-2", " ", 1);
+        when(robotExecuteDao.getRobotExecute("robot-2", "user-2", "tenant-2")).thenReturn(robot);
+        when(executorModeHandler.getParamInside4NewVersion(
+                        any(QueryParamDto.class), eq("user-2"), eq("tenant-2"), eq(1)))
+                .thenReturn(emptyParameters());
+        stubSuccessfulPost();
+
+        service.sendOpenApi("robot-2", 1, "user-2", "tenant-2");
+
+        JSONObject request = JSONObject.parseObject(captureRequest("user-2").getBody());
+        assertEquals("robot-2", request.getString("name"));
+        assertEquals("robot-2", request.getString("english_name"));
+    }
+
+    @Test
+    void shouldUseRobotIdWhenPublishedRobotCannotBeLoaded() throws Exception {
+        when(robotExecuteDao.getRobotExecute("robot-missing", "user-2", "tenant-2"))
+                .thenReturn(null);
+        when(executorModeHandler.getParamInside4NewVersion(
+                        any(QueryParamDto.class), eq("user-2"), eq("tenant-2"), eq(1)))
+                .thenReturn(emptyParameters());
+        stubSuccessfulPost();
+
+        service.sendOpenApi("robot-missing", 1, "user-2", "tenant-2");
+
+        JSONObject request = JSONObject.parseObject(captureRequest("user-2").getBody());
+        assertEquals("robot-missing", request.getString("name"));
+    }
+
+    @Test
+    void shouldPreserveExampleWorkflowMappingDuringSynchronization() throws Exception {
+        RobotExecute robot = robot("robot-3", "Example Bot", 4);
+        when(robotExecuteDao.getExpoUserRobotId("Example Bot", "example-user")).thenReturn("example-robot-3");
+        when(executorModeHandler.getParamInside(any(QueryParamDto.class), eq("user-3"), eq("tenant-3")))
+                .thenReturn(emptyParameters());
+        stubSuccessfulPost();
+
+        ReflectionTestUtils.invokeMethod(service, "sendOpenApiRequest", robot, "user-3", "tenant-3");
+
+        JSONObject request = JSONObject.parseObject(captureRequest("user-3").getBody());
+        assertEquals("example-robot-3", request.getString("example_project_id"));
+        assertEquals("Example Bot", request.getString("name"));
+        assertEquals(1, request.getInteger("status"));
+        assertEquals(4, request.getInteger("version"));
+    }
+
+    @Test
+    void shouldPropagateWorkflowSynchronizationFailure() throws Exception {
+        RobotExecute robot = robot("robot-4", "Failing Bot", 1);
+        when(robotExecuteDao.getRobotExecute("robot-4", "user-4", "tenant-4")).thenReturn(robot);
+        when(executorModeHandler.getParamInside4NewVersion(
+                        any(QueryParamDto.class), eq("user-4"), eq("tenant-4"), eq(1)))
+                .thenReturn(emptyParameters());
+        when(restTemplate.exchange(eq(UPSERT_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("unreachable"));
+
+        assertThrows(ResourceAccessException.class, () -> service.sendOpenApi("robot-4", 1, "user-4", "tenant-4"));
+    }
+
+    @Test
+    void shouldPropagateExampleWorkflowSynchronizationFailure() throws Exception {
+        RobotExecute robot = robot("robot-5", "Example Failure", 1);
+        when(robotExecuteDao.getExpoUserRobotId("Example Failure", "example-user"))
+                .thenReturn("example-robot-5");
+        when(executorModeHandler.getParamInside(any(QueryParamDto.class), eq("user-5"), eq("tenant-5")))
+                .thenReturn(emptyParameters());
+        when(restTemplate.exchange(eq(UPSERT_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("unreachable"));
+
+        assertThrows(
+                ResourceAccessException.class,
+                () -> ReflectionTestUtils.invokeMethod(service, "sendOpenApiRequest", robot, "user-5", "tenant-5"));
+    }
+
+    @Test
+    void shouldCreateDefaultRestTemplate() {
+        assertNotNull(new SampleUsersServiceImpl().createRestTemplate());
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpEntity<String> captureRequest(String expectedUserId) {
+        ArgumentCaptor<HttpEntity<String>> requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(UPSERT_URL), eq(HttpMethod.POST), requestCaptor.capture(), eq(String.class));
+        HttpEntity<String> request = requestCaptor.getValue();
+        assertEquals("application/json", request.getHeaders().getContentType().toString());
+        assertEquals(expectedUserId, request.getHeaders().getFirst("user_id"));
+        return request;
+    }
+
+    private void stubSuccessfulPost() {
+        when(restTemplate.exchange(eq(UPSERT_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("{}"));
+    }
+
+    private AppResponse<List<ParamDto>> emptyParameters() {
+        return AppResponse.success(Collections.emptyList());
+    }
+
+    private RobotExecute robot(String robotId, String name, int version) {
+        RobotExecute robot = new RobotExecute();
+        robot.setRobotId(robotId);
+        robot.setName(name);
+        robot.setRobotVersion(version);
+        return robot;
+    }
+}

--- a/backend/robot-service/src/test/java/com/iflytek/rpa/robot/service/impl/RobotDesignServiceImplTest.java
+++ b/backend/robot-service/src/test/java/com/iflytek/rpa/robot/service/impl/RobotDesignServiceImplTest.java
@@ -1,0 +1,77 @@
+package com.iflytek.rpa.robot.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.alibaba.fastjson.JSONObject;
+import com.iflytek.rpa.example.config.OpenApiProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+class RobotDesignServiceImplTest {
+
+    private static final String UPSERT_URL = "http://openapi-service:8020/workflows/upsert";
+
+    private RobotDesignServiceImpl service;
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        service = spy(new RobotDesignServiceImpl());
+        restTemplate = mock(RestTemplate.class);
+        OpenApiProperties properties = new OpenApiProperties();
+        properties.setWorkflowsUpsertUrl(UPSERT_URL);
+        ReflectionTestUtils.setField(service, "openApiProperties", properties);
+        doReturn(restTemplate).when(service).createRestTemplate();
+    }
+
+    @Test
+    void shouldDeactivateWorkflowAtConfiguredUrlWhenRobotIsDeleted() {
+        when(restTemplate.exchange(eq(UPSERT_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("{}"));
+
+        ReflectionTestUtils.invokeMethod(service, "sendDeleteRequestToOpenApi", "robot-1", "user-1");
+
+        ArgumentCaptor<HttpEntity<String>> requestCaptor = captureRequest();
+        JSONObject request = JSONObject.parseObject(requestCaptor.getValue().getBody());
+        assertEquals("robot-1", request.getString("project_id"));
+        assertEquals(0, request.getInteger("status"));
+        assertEquals("user-1", requestCaptor.getValue().getHeaders().getFirst("user_id"));
+    }
+
+    @Test
+    void shouldKeepDeleteOperationCompatibleWhenOpenApiIsUnavailable() {
+        when(restTemplate.exchange(eq(UPSERT_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("unreachable"));
+
+        assertDoesNotThrow(
+                () -> ReflectionTestUtils.invokeMethod(service, "sendDeleteRequestToOpenApi", "robot-2", "user-2"));
+    }
+
+    @Test
+    void shouldCreateDefaultRestTemplate() {
+        assertNotNull(new RobotDesignServiceImpl().createRestTemplate());
+    }
+
+    @SuppressWarnings("unchecked")
+    private ArgumentCaptor<HttpEntity<String>> captureRequest() {
+        ArgumentCaptor<HttpEntity<String>> requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(eq(UPSERT_URL), eq(HttpMethod.POST), requestCaptor.capture(), eq(String.class));
+        return requestCaptor;
+    }
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -56,3 +56,6 @@ CASDOOR_ORGANIZATION_NAME="example-org"
 CASDOOR_APPLICATION_NAME="example-app"
 CASDOOR_REDIRECT_URL="https://tauri.localhost/"
 CASDOOR_EXTERNAL_ENDPOINT="http://127.0.0.1:8000"
+
+# Robot Service -> OpenAPI Service workflow synchronization
+OPENAPI_WORKFLOWS_UPSERT_URL="http://openapi-service:8020/workflows/upsert"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -292,6 +292,8 @@ services:
     container_name: rpa-opensource-robot-service
     restart: always
     env_file: *env_file
+    environment:
+      - OPENAPI_WORKFLOWS_UPSERT_URL=${OPENAPI_WORKFLOWS_UPSERT_URL:-http://openapi-service:8020/workflows/upsert}
     # ports:
     #   - "8040:8040"
     volumes:


### PR DESCRIPTION
This closes #859.

- 🐛 Bug 修复 | Bug Fix

## 概述

修复 `robot-service` 向 `openapi-service` 同步工作流时使用了错误容器地址的问题，并补齐工作流发布所需的活动状态和名称等元数据，保证已发布工作流能够被 MCP `tools/list` 发现。
使用了兼容性修复：保留原同步地址作为未配置时的回退值，官方 Docker Compose 使用正确服务地址，允许部署方通过环境变量覆盖。

## 变更内容 | Changes Made

### 1. 工作流同步地址配置化

- 新增 `OpenApiProperties`，集中管理工作流同步地址。
- 保留旧地址 `http://rpa-openapi:6699/workflows/upsert` 作为兼容回退。
- Docker Compose 默认使用实际存在的内部地址：  `http://openapi-service:8020/workflows/upsert`。
- 新增 `OPENAPI_WORKFLOWS_UPSERT_URL` 环境变量，支持自定义部署。
- 发布同步、示例工作流同步和删除同步统一读取配置。

### 2. 补齐已发布工作流元数据

- 新增统一的已发布工作流 DTO 构建方法。
- 同步以下字段：
  - `project_id`
  - `name`
  - `english_name`
  - `description`
  - `version`
  - `status = 1`
  - `parameters`
  - `example_project_id`
- 工作流名称为空或查询不到记录时，使用 `robotId` 作为兼容兜底。
- 保留原有异步发布、异常传播及删除失败容错逻辑。

## 测试

### UT测试
- 验证默认旧地址和部署地址覆盖。
- 验证空配置自动回退旧地址。
- 验证发布 DTO 的活动状态、名称、版本和示例项目映射。
- 验证普通发布和示例工作流同步的 URL、请求头及请求体。
- 验证名称为空或工作流记录不存在时的兜底行为。
- 验证同步失败保持原有异常语义。
- 验证删除同步失败不会影响原删除操作。
- 验证 MCP 只发现活动工作流。
- 验证工作流查询使用已认证用户进行隔离。

###测试结果
- robot-service Java UT：`16 passed`
- openapi-service Python UT：`3 passed`
- 本次 Java 可执行变更行：`41/41`
- 本次新增或修改分支：`14/14`
- Java Spotless：通过
- Python Ruff：通过
- Docker Compose Schema：通过
- `git diff --check`：通过

### 检查清单

- [x] 已修复官方 Compose 中的工作流同步地址
- [x] 保留旧部署地址作为兼容回退
- [x] 支持通过环境变量覆盖同步地址
- [x] 已发布工作流同步为活动状态
- [x] 已补齐 MCP 工具发现所需元数据
- [x] 发布、示例同步和删除同步均使用统一配置
- [x] 未改变原有发布事务和异步执行逻辑
- [x] 未改变原有鉴权和 MCP 协议逻辑
- [x] 删除同步失败仍不会影响原删除操作
- [x] 本次代码变更的 UT 行覆盖和分支覆盖均为 100%
- [x] 相关格式检查和配置校验通过
- [ ] 尚未在实际 Docker 容器中执行端到端联调