### PR TITLE
fix(verifycode): release mouse after slider failures

### DIFF
--- a/.github/workflows/verifycode-mouse-release.yml
+++ b/.github/workflows/verifycode-mouse-release.yml
@@ -1,0 +1,26 @@
+name: Verify slider mouse cleanup
+
+on:
+  pull_request:
+    paths:
+      - 'engine/components/astronverse-verifycode/**'
+      - '.github/workflows/verifycode-mouse-release.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'engine/components/astronverse-verifycode/**'
+      - '.github/workflows/verifycode-mouse-release.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  mouse-release:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Run mouse-release regressions
+        run: python engine/components/astronverse-verifycode/tests/test_mouse_release.py -v

--- a/engine/components/astronverse-verifycode/src/astronverse/verifycode/core.py
+++ b/engine/components/astronverse-verifycode/src/astronverse/verifycode/core.py
@@ -1,6 +1,7 @@
 import base64
 import random
 import re
+import sys
 import time
 from io import BytesIO
 
@@ -47,17 +48,29 @@ class VerifyCodeCore:
         start_pos = (start_pos.x, start_pos.y)
         smooth_move(*start_pos, duration=0.5)
         pyautogui.mouseDown(*start_pos, button="left")
-        time.sleep(0.5)
-        # 为了绕过轨迹验证
-        distance = end_pos[0] - start_pos[0]
-        pos_1 = [start_pos[0] + distance * 0.7, end_pos[1] + 10]
-        smooth_move(*pos_1, duration=random.choice([0.2, 0.4, 0.6]))
-        pos_1 = [start_pos[0] + distance * 0.8, end_pos[1] + 10]
-        smooth_move(*pos_1, duration=random.choice([0.2, 0.4, 0.61]))
-        pos_1 = [start_pos[0] + distance * 1.2, end_pos[1] + 10]
-        smooth_move(*pos_1, duration=random.choice([0.2, 0.4, 0.6]))
-        smooth_move(*end_pos, duration=0.2)
-        pyautogui.mouseUp(*end_pos, button="left")
+        try:
+            time.sleep(0.5)
+            # 为了绕过轨迹验证
+            distance = end_pos[0] - start_pos[0]
+            pos_1 = [start_pos[0] + distance * 0.7, end_pos[1] + 10]
+            smooth_move(*pos_1, duration=random.choice([0.2, 0.4, 0.6]))
+            pos_1 = [start_pos[0] + distance * 0.8, end_pos[1] + 10]
+            smooth_move(*pos_1, duration=random.choice([0.2, 0.4, 0.61]))
+            pos_1 = [start_pos[0] + distance * 1.2, end_pos[1] + 10]
+            smooth_move(*pos_1, duration=random.choice([0.2, 0.4, 0.6]))
+            smooth_move(*end_pos, duration=0.2)
+        finally:
+            VerifyCodeCore.release_left_button()
+
+    @staticmethod
+    def release_left_button():
+        original_error = sys.exc_info()[1]
+        try:
+            pyautogui.mouseUp(button="left")
+        except Exception:
+            if original_error is None:
+                raise
+            logger.exception("Failed to release the left mouse button after a slider error")
 
     @staticmethod
     def get_margin_left(browser_obj, element):

--- a/engine/components/astronverse-verifycode/src/astronverse/verifycode/verifycode.py
+++ b/engine/components/astronverse-verifycode/src/astronverse/verifycode/verifycode.py
@@ -91,6 +91,9 @@ class VerifyCode:
         mini_step: int = 5,
         offset: int = 0,
     ) -> int:
+        if unmatched_flag and mini_step <= 0:
+            raise ValueError("mini_step must be greater than zero")
+
         element = Locator.locator(picture_pick.get("elementData"), cur_target_app=browser_obj.browser_type.value)
         rect = element.rect()
         image_base64 = VerifyCodeCore.get_base64_screenshot(rect.left, rect.top, rect.width(), rect.height())
@@ -112,22 +115,24 @@ class VerifyCode:
         else:
             smooth_move(start_pos.x, start_pos.y, duration=0.5)
             pyautogui.mouseDown()
-            smooth_move(start_pos.x + drag_distance * 0.85, start_pos.y, duration=0.5)
-            time.sleep(0.5)
-            delta = drag_distance - round(float(VerifyCodeCore.get_margin_left(browser_obj, move_pic_pick)))
-            logger.info(delta)
-            while abs(delta) > mini_step:
-                if delta > 0:
-                    smooth_move(pyautogui.position().x + mini_step, start_pos.y, duration=0.5)
-                    # pyautogui.moveTo(pyautogui.position().x + mini_step, start_pos.y, duration=0.5)
-                else:
-                    smooth_move(pyautogui.position().x - mini_step, start_pos.y, duration=0.5)
-                    # pyautogui.moveTo(pyautogui.position().x - mini_step, start_pos.y, duration=0.5)
+            try:
+                deadline = time.monotonic() + 30
+                smooth_move(start_pos.x + drag_distance * 0.85, start_pos.y, duration=0.5)
                 time.sleep(0.5)
                 delta = drag_distance - round(float(VerifyCodeCore.get_margin_left(browser_obj, move_pic_pick)))
                 logger.info(delta)
-            # 释放滑块
-            pyautogui.mouseUp()
+                while abs(delta) > mini_step:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("Slider adjustment did not finish within 30 seconds")
+                    if delta > 0:
+                        smooth_move(pyautogui.position().x + mini_step, start_pos.y, duration=0.5)
+                    else:
+                        smooth_move(pyautogui.position().x - mini_step, start_pos.y, duration=0.5)
+                    time.sleep(0.5)
+                    delta = drag_distance - round(float(VerifyCodeCore.get_margin_left(browser_obj, move_pic_pick)))
+                    logger.info(delta)
+            finally:
+                VerifyCodeCore.release_left_button()
 
         return drag_distance
 

--- a/engine/components/astronverse-verifycode/tests/test_mouse_release.py
+++ b/engine/components/astronverse-verifycode/tests/test_mouse_release.py
@@ -1,0 +1,124 @@
+"""Exercise real slider methods without importing desktop or recognition services."""
+
+# Keep these dependency-free regressions runnable with the standard-library test runner.
+# ruff: noqa: PT009, PT027
+
+from __future__ import annotations
+
+import ast
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+SOURCE = Path(__file__).resolve().parents[1] / "src/astronverse/verifycode"
+
+
+def load_method(filename, class_name, method_name, namespace):
+    tree = ast.parse((SOURCE / filename).read_text(encoding="utf-8"))
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name)
+    method = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == method_name)
+    method.decorator_list = []
+    module = ast.Module(body=[method], type_ignores=[])
+    exec(compile(module, filename, "exec"), namespace)  # noqa: S102 - trusted repository source
+    return namespace[method_name]
+
+
+class MouseReleaseTest(unittest.TestCase):
+    def setUp(self):
+        self.mouse = SimpleNamespace(
+            mouseDown=Mock(), mouseUp=Mock(), position=Mock(return_value=SimpleNamespace(x=100))
+        )
+        self.move = Mock()
+        self.clock = SimpleNamespace(sleep=Mock(), monotonic=Mock(return_value=0))
+        self.core = SimpleNamespace(
+            get_base64_screenshot=Mock(return_value="image"),
+            get_api_result=Mock(return_value="100"),
+            get_margin_left=Mock(return_value="100"),
+            html_drag_plus=Mock(),
+        )
+        rect = SimpleNamespace(left=0, top=0, width=lambda: 100, height=lambda: 20)
+        element = SimpleNamespace(rect=lambda: rect, point=lambda: SimpleNamespace(x=10, y=20))
+        self.namespace = {
+            "pyautogui": self.mouse,
+            "smooth_move": self.move,
+            "time": self.clock,
+            "sys": sys,
+            "random": SimpleNamespace(choice=Mock(return_value=0.2)),
+            "VerifyCodeCore": self.core,
+            "Locator": SimpleNamespace(locator=Mock(return_value=element)),
+            "logger": Mock(),
+        }
+        self.core.release_left_button = load_method("core.py", "VerifyCodeCore", "release_left_button", self.namespace)
+        self.drag = load_method("core.py", "VerifyCodeCore", "html_drag_plus", self.namespace)
+        self.slider = load_method("verifycode.py", "VerifyCode", "slider_code", self.namespace)
+        self.slider_args = {
+            "browser_obj": SimpleNamespace(browser_type=SimpleNamespace(value="chrome")),
+            "picture_pick": {"elementData": {}},
+            "slider_pick": {"elementData": {}},
+            "unmatched_flag": True,
+        }
+
+    def test_normal_drag_releases_mouse_at_destination(self):
+        self.drag(SimpleNamespace(x=10, y=20), (110, 20))
+        self.move.assert_called_with(110, 20, duration=0.2)
+        self.mouse.mouseUp.assert_called_once_with(button="left")
+
+    def test_drag_failure_releases_mouse_and_preserves_error(self):
+        error = RuntimeError("movement failed")
+        self.move.side_effect = [None, error]
+        with self.assertRaises(RuntimeError) as caught:
+            self.drag(SimpleNamespace(x=10, y=20), (110, 20))
+        self.assertIs(caught.exception, error)
+        self.mouse.mouseUp.assert_called_once_with(button="left")
+
+    def test_drag_interruption_releases_mouse(self):
+        self.clock.sleep.side_effect = KeyboardInterrupt
+        with self.assertRaises(KeyboardInterrupt):
+            self.drag(SimpleNamespace(x=10, y=20), (110, 20))
+        self.mouse.mouseUp.assert_called_once_with(button="left")
+
+    def test_unmatched_slider_releases_on_success(self):
+        self.assertEqual(self.slider(**self.slider_args), 100)
+        self.mouse.mouseUp.assert_called_once_with(button="left")
+
+    def test_unmatched_slider_releases_when_element_disappears(self):
+        error = RuntimeError("element disappeared")
+        self.core.get_margin_left.side_effect = error
+        with self.assertRaises(RuntimeError) as caught:
+            self.slider(**self.slider_args)
+        self.assertIs(caught.exception, error)
+        self.mouse.mouseUp.assert_called_once_with(button="left")
+
+    def test_nonconverging_slider_times_out_and_releases(self):
+        self.core.get_margin_left.side_effect = ["0", "0", RuntimeError("unbounded adjustment")]
+        self.clock.monotonic.side_effect = [0, 1, 31]
+        with self.assertRaisesRegex(TimeoutError, "30 seconds"):
+            self.slider(**self.slider_args)
+        self.mouse.mouseUp.assert_called_once_with(button="left")
+        self.assertEqual(self.core.get_margin_left.call_count, 2)
+
+    def test_release_failure_preserves_original_drag_error(self):
+        original = RuntimeError("movement failed")
+        self.move.side_effect = [None, original]
+        self.mouse.mouseUp.side_effect = RuntimeError("release failed")
+        with self.assertRaises(RuntimeError) as caught:
+            self.drag(SimpleNamespace(x=10, y=20), (110, 20))
+        self.assertIs(caught.exception, original)
+        self.namespace["logger"].exception.assert_called_once()
+
+    def test_release_failure_after_success_is_reported(self):
+        self.mouse.mouseUp.side_effect = RuntimeError("release failed")
+        with self.assertRaisesRegex(RuntimeError, "release failed"):
+            self.drag(SimpleNamespace(x=10, y=20), (110, 20))
+
+    def test_invalid_step_is_rejected_before_mouse_is_pressed(self):
+        for step in (0, -1):
+            with self.subTest(step=step), self.assertRaisesRegex(ValueError, "mini_step"):
+                self.slider(**self.slider_args, mini_step=step)
+        self.mouse.mouseDown.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Problem and change

Refs #667.

Both slider paths can leave the left mouse button pressed when movement or element lookup raises after `mouseDown`. The unmatched-slider adjustment loop can also run indefinitely when the reported position stops changing.

- Release the left button in `finally` for both existing drag paths.
- Reject nonpositive adjustment steps before pressing the mouse.
- Stop a nonconverging adjustment loop after 30 seconds and report a timeout.
- Preserve the original execution exception if release itself fails, and log that cleanup failure. A cleanup failure after otherwise successful execution still propagates.
- Add a Windows/Python 3.13 CI job for nine dependency-free regression cases.

## Validation

- Python 3.13.14: nine regression tests passed. Tests execute the real method bodies with simulated desktop/recognition dependencies, covering success, movement failure, interruption, missing elements, nonconvergence, invalid steps, and release failures.
- Component Ruff format check passed; new-test Ruff check passed.
- Source-file Ruff findings were compared with current `main`: the same seven pre-existing findings remain, with no new findings.
- Python compilation and `git diff --check` passed.
- `make check` could not run because GNU Make is not installed in this Windows environment; the relevant Python checks above were run directly.

## Scope and remaining verification

This improves mouse cleanup for the reproduced control-flow failures. No live browser, recognition endpoint, or Windows desktop was exercised, so the original reporter's environment still needs verification and this PR does not automatically close #667. The 30-second deadline is checked between adjustment iterations; it cannot interrupt a blocked external call.

PyAutoGUI may itself reject `mouseUp` when its fail-safe is active. The change keeps that fail-safe enabled and preserves the original error if cleanup also fails; it does not claim to solve fail-safe corner cases. Existing recognition and drag trajectory logic are unchanged.
